### PR TITLE
Support a context when showing error messages

### DIFF
--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -725,7 +725,6 @@ defmodule NimbleOptionsTest do
   end
 
   describe "nested options show up in error messages" do
-    @tag :focus
     test "for options that we validate" do
       schema = [
         socket_options: [


### PR DESCRIPTION
Closes #14.

Implementation is kind of thrown out there, didn't spend too much time making things nice 😄 I'm also very interested in what format you think would work best. Not sure my choice of wording/error message is clear to read. Any ways, this is a first pass to get something working at least, because without this my experience has been that it's really hard to figure out where an error message is coming from. :)

cc @josevalim @msaraiva 