### PR TITLE
Remove unreachable code on `NimbleOptions`

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -274,15 +274,6 @@ defmodule NimbleOptions do
     end
   end
 
-  defp reduce_options({key, schema_fun}, opts) when is_function(schema_fun) do
-    reduce_options({key, schema_fun.()}, opts)
-  end
-
-  defp reduce_options({key, {schema_fun, overrides}}, opts) when is_function(schema_fun) do
-    schema_opts = Keyword.merge(schema_fun.(), overrides || [])
-    reduce_options({key, schema_opts}, opts)
-  end
-
   defp reduce_options({key, schema_opts}, opts) do
     case validate_option(opts, key, schema_opts) do
       {:error, _message, _path} = result ->


### PR DESCRIPTION
I just started checking this library, and it looks great, thanks for your hard
work.

I _think_ these two cases of the private function `reduce_options/2` are not
reachable, sorry in advance if that's not the case. I did review the unit
tests, and there I don't see any code that could be reaching these functions.