### PR TITLE
Add pid type

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -89,6 +89,8 @@ defmodule NimbleOptions do
 
     * `:timeout` - A non-negative integer or the atom `:infinity`.
 
+    * `:pid` - A PID (process identifier).
+
     * `:mfa` - A named function in the format `{module, function, arity}`
 
     * `:mod_arg` - A module along with arguments, e.g. `{MyModule, [arg1, arg2]}`.
@@ -172,7 +174,8 @@ defmodule NimbleOptions do
     :mod_arg,
     :string,
     :boolean,
-    :timeout
+    :timeout,
+    :pid
   ]
 
   @type schema() :: keyword()
@@ -382,6 +385,14 @@ defmodule NimbleOptions do
     else
       {:error, "expected #{inspect(key)} to be a non-empty keyword list, got: #{inspect(value)}"}
     end
+  end
+
+  defp validate_type(:pid, _key, value) when is_pid(value) do
+    :ok
+  end
+
+  defp validate_type(:pid, key, value) do
+    {:error, "expected #{inspect(key)} to be a pid, got: #{inspect(value)}"}
   end
 
   defp validate_type(:mfa, _key, {m, f, args}) when is_atom(m) and is_atom(f) and is_list(args) do

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -30,7 +30,7 @@ defmodule NimbleOptionsTest do
 
       Available types: :any, :keyword_list, :non_empty_keyword_list, :atom, \
       :non_neg_integer, :pos_integer, :mfa, :mod_arg, :string, :boolean, :timeout, \
-      {:fun, arity}, {:one_of, choices}, {:custom, mod, fun, args}\
+      :pid, {:fun, arity}, {:one_of, choices}, {:custom, mod, fun, args}\
       """
 
       assert_raise ArgumentError, message, fn ->
@@ -272,7 +272,7 @@ defmodule NimbleOptionsTest do
       schema = [name: [type: :pid]]
 
       assert NimbleOptions.validate([name: 1], schema) ==
-               {:error, "expected :name to be an pid, got: 1"}
+               {:error, "expected :name to be a pid, got: 1"}
     end
 
     test "valid mfa" do

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -262,6 +262,19 @@ defmodule NimbleOptionsTest do
                 "expected :timeout to be non-negative integer or :infinity, got: :invalid"}
     end
 
+    test "valid pid" do
+      schema = [name: [type: :pid]]
+      opts = [name: self()]
+      assert NimbleOptions.validate(opts, schema) == {:ok, opts}
+    end
+
+    test "invalid pid" do
+      schema = [name: [type: :pid]]
+
+      assert NimbleOptions.validate([name: 1], schema) ==
+               {:error, "expected :name to be an pid, got: 1"}
+    end
+
     test "valid mfa" do
       schema = [transformer: [type: :mfa]]
 


### PR DESCRIPTION
Hello! I was looking to use this library in a project of mine, but one of the types I'm passing is a PID. 

This PR adds `:pid` to possible types. I *think* I've updated all of the documentation and added the correct tests. Please let me know if I missed something!

Edit: I also wasn't sure if I should update the changelog, or if that only got updated when a release went out.