### PR TITLE
Validate default values

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -305,7 +305,8 @@ defmodule NimbleOptions do
 
       :no_value ->
         if Keyword.has_key?(schema_opts, :default) do
-          {:cont, Keyword.put(opts, key, schema_opts[:default])}
+          opts_with_default = Keyword.put(opts, key, schema_opts[:default])
+          reduce_options({key, schema_opts}, opts_with_default)
         else
           {:cont, opts}
         end


### PR DESCRIPTION
Currently, default values are not validated so if the user changes the schema and forgets to update related default values accordingly, the resulting options returned by `validate` will contain invalid options. This PR fixes the issue and also allows addressing #49 more consistently by setting `[]` as a default value.