### PR TITLE
Introduce a :or type

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -562,7 +562,7 @@ defmodule NimbleOptions do
     Enum.reduce_while(subtypes, {:ok, value}, fn subtype, acc ->
       case type(subtype) do
         {:ok, _value} -> {:cont, acc}
-        {:error, reason} -> {:halt, {:error, "invalid type in :or for reaso: #{reason}"}}
+        {:error, reason} -> {:halt, {:error, "invalid type in :or for reason: #{reason}"}}
       end
     end)
   end

--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -489,16 +489,13 @@ defmodule NimbleOptions do
     result =
       Enum.reduce_while(subtypes, _errors = [], fn subtype, errors_acc ->
         case validate_type(subtype, key, value) do
-          :ok -> {:halt, :ok}
+          :ok -> {:halt, {:ok, value}}
           {:ok, value} -> {:halt, {:ok, value}}
           {:error, %ValidationError{} = reason} -> {:cont, [reason | errors_acc]}
         end
       end)
 
     case result do
-      :ok ->
-        :ok
-
       {:ok, value} ->
         {:ok, value}
 

--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -537,7 +537,7 @@ defmodule NimbleOptions do
   defp available_types() do
     types =
       Enum.map(@basic_types, &inspect/1) ++
-        ["{:fun, arity}", "{:in, choices}", "{:custom, mod, fun, args}"]
+        ["{:fun, arity}", "{:in, choices}", "{:or, subtypes}", "{:custom, mod, fun, args}"]
 
     Enum.join(types, ", ")
   end

--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -102,9 +102,9 @@ defmodule NimbleOptions do
 
     * `{:fun, arity}` - Any function with the specified arity.
 
-    * `{:one_of, choices}` - A value that is a member of one of the `choices`. `choices`
+    * `{:in, choices}` - A value that is a member of one of the `choices`. `choices`
       should be a list of terms. The value is an element in said list of terms,
-      that is, `value in choices` is `true`.
+      that is, `value in choices` is `true`. Previously called `:one_of`.
 
     * `{:custom, mod, fun, args}` - A custom type. The related value must be validated
       by `mod.fun(values, ...args)`. The function should return `{:ok, value}` or
@@ -468,7 +468,12 @@ defmodule NimbleOptions do
     end
   end
 
+  # TODO: remove on v0.5.
   defp validate_type({:one_of, choices}, key, value) do
+    validate_type({:in, choices}, key, value)
+  end
+
+  defp validate_type({:in, choices}, key, value) do
     if value in choices do
       :ok
     else
@@ -535,7 +540,7 @@ defmodule NimbleOptions do
   defp available_types() do
     types =
       Enum.map(@basic_types, &inspect/1) ++
-        ["{:fun, arity}", "{:one_of, choices}", "{:custom, mod, fun, args}"]
+        ["{:fun, arity}", "{:in, choices}", "{:custom, mod, fun, args}"]
 
     Enum.join(types, ", ")
   end
@@ -549,7 +554,13 @@ defmodule NimbleOptions do
     {:ok, value}
   end
 
-  def type({:one_of, choices} = value) when is_list(choices) do
+  # TODO: remove on v0.5.
+  def type({:one_of, choices}) do
+    IO.warn("the {:one_of, choices} type is deprecated. Use {:in, choices} instead.")
+    type({:in, choices})
+  end
+
+  def type({:in, choices} = value) when is_list(choices) do
     {:ok, value}
   end
 

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -619,7 +619,6 @@ defmodule NimbleOptionsTest do
     end
 
     test "invalid {:or, subtypes} with nested :or" do
-      # Nested :or.
       schema = [
         docs: [
           type:

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -39,7 +39,8 @@ defmodule NimbleOptionsTest do
 
       Available types: :any, :keyword_list, :non_empty_keyword_list, :atom, \
       :integer, :non_neg_integer, :pos_integer, :mfa, :mod_arg, :string, :boolean, :timeout, \
-      :pid, {:fun, arity}, {:in, choices}, {:custom, mod, fun, args} (in options [:stages])\
+      :pid, {:fun, arity}, {:in, choices}, {:or, subtypes}, {:custom, mod, fun, args} \
+      (in options [:stages])\
       """
 
       assert_raise ArgumentError, message, fn ->


### PR DESCRIPTION
It's missing docs still, but I think this is a pretty low hanging fruit. Reasons why I'm okay with this:

* the error message comes out nicely by combining all the error messages
* "casting" works okay by just casting as the first matching type
* I've used this a billion times through `{:custom, ...}` in my code already eheh

Thoughts before I write docs? :)