### PR TITLE
Support nested schemas in the :or type

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -117,8 +117,8 @@ defmodule NimbleOptions do
       subtypes is a keyword list, you won't be able to pass `:keys` directly. For this reason,
       keyword lists (`:keyword_list` and `:non_empty_keyword_list`) are special cased and can
       be used as subtypes with `{:keyword_list, keys}` or `{:non_empty_keyword_list, keys}`.
-      For example, a type such as `{:or, [:boolean, {:keyword_list, enabled: [type: :boolean]}]}`
-      would match either a boolean or a keyword list with the `:enabled` option in it.
+      For example, a type such as `{:or, [:boolean, keyword_list: [enabled: [type: :boolean]]]}`
+      would match either a boolean or a keyword list with the `:enabled` boolean option in it.
 
   ## Example
 

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -605,7 +605,7 @@ defmodule NimbleOptionsTest do
     test "valid {:or, subtypes} with nested keyword lists" do
       schema = [
         docs: [
-          type: {:or, [:boolean, {:keyword_list, enabled: [type: :boolean]}]}
+          type: {:or, [:boolean, keyword_list: [enabled: [type: :boolean]]]}
         ]
       ]
 
@@ -669,7 +669,7 @@ defmodule NimbleOptionsTest do
     test "invalid {:or, subtypes} with nested keyword lists" do
       schema = [
         docs: [
-          type: {:or, [:boolean, {:keyword_list, enabled: [type: :boolean]}]}
+          type: {:or, [:boolean, keyword_list: [enabled: [type: :boolean]]]}
         ]
       ]
 


### PR DESCRIPTION
@josevalim I completely overlooked nested schemas in #54. This to me seems like the best (= least horrible, still pretty ugly) way of dealing with them.

```elixir
schema = [
  docs: [
    type: {:or, [:boolean, {:keyword_list, enabled: [type: :boolean]}]}
  ]
]
```

Thoughts?