### PR TITLE
Support a nesting level in NimbleOptions.docs/2

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -69,7 +69,7 @@ defmodule NimbleOptions do
   These are the options supported in a *schema*. They are what
   defines the validation for the items in the given schema.
 
-  #{NimbleOptions.Docs.generate(@options_schema, _nest_levels = 0)}
+  #{NimbleOptions.Docs.generate(@options_schema, nest_levels: 0)}
 
   ## Types
 
@@ -255,11 +255,33 @@ defmodule NimbleOptions do
 
       @doc "Supported options:\n#{NimbleOptions.docs(@options_schema)}"
 
+  ## Options
+
+    * `:nest_levels` - an integer deciding the "nest level" of the generated
+      docs. This is useful when, for example, you use `docs/2` inside the `:doc`
+      option of another schema. For example, if you have the following nested schema:
+
+          nested_schema = [
+            allowed_messages: [type: :pos_integer, doc: "Allowed messages."],
+            interval: [type: :pos_integer, doc: "Interval."]
+          ]
+
+      then you can document it inside another schema with its nesting level increased:
+
+          schema = [
+            producer: [
+              type: {:or, [:string, keyword_list: nested_schema]},
+              doc:
+                "Either a string or a keyword list with the following keys:\n\n" <>
+                  NimbleOptions.docs(nested_schema, nest_levels: 1)
+            ],
+            other_key: [type: :string]
+          ]
+
   """
-  @spec docs(schema(), non_neg_integer()) :: String.t()
-  def docs(schema, nest_levels \\ 0)
-      when is_list(schema) and is_integer(nest_levels) and nest_levels >= 0 do
-    NimbleOptions.Docs.generate(schema, nest_levels)
+  @spec docs(schema(), keyword()) :: String.t()
+  def docs(schema, options \\ []) when is_list(schema) and is_list(options) do
+    NimbleOptions.Docs.generate(schema, options)
   end
 
   @doc false

--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -69,7 +69,7 @@ defmodule NimbleOptions do
   These are the options supported in a *schema*. They are what
   defines the validation for the items in the given schema.
 
-  #{NimbleOptions.Docs.generate(@options_schema)}
+  #{NimbleOptions.Docs.generate(@options_schema, _nest_levels = 0)}
 
   ## Types
 
@@ -256,9 +256,10 @@ defmodule NimbleOptions do
       @doc "Supported options:\n#{NimbleOptions.docs(@options_schema)}"
 
   """
-  @spec docs(schema()) :: String.t()
-  def docs(schema) when is_list(schema) do
-    NimbleOptions.Docs.generate(schema)
+  @spec docs(schema(), non_neg_integer()) :: String.t()
+  def docs(schema, nest_levels \\ 0)
+      when is_list(schema) and is_integer(nest_levels) and nest_levels >= 0 do
+    NimbleOptions.Docs.generate(schema, nest_levels)
   end
 
   @doc false

--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -69,7 +69,7 @@ defmodule NimbleOptions do
   These are the options supported in a *schema*. They are what
   defines the validation for the items in the given schema.
 
-  #{NimbleOptions.Docs.generate(@options_schema, nest_levels: 0)}
+  #{NimbleOptions.Docs.generate(@options_schema, nest_level: 0)}
 
   ## Types
 
@@ -257,7 +257,7 @@ defmodule NimbleOptions do
 
   ## Options
 
-    * `:nest_levels` - an integer deciding the "nest level" of the generated
+    * `:nest_level` - an integer deciding the "nest level" of the generated
       docs. This is useful when, for example, you use `docs/2` inside the `:doc`
       option of another schema. For example, if you have the following nested schema:
 
@@ -273,7 +273,7 @@ defmodule NimbleOptions do
               type: {:or, [:string, keyword_list: nested_schema]},
               doc:
                 "Either a string or a keyword list with the following keys:\n\n" <>
-                  NimbleOptions.docs(nested_schema, nest_levels: 1)
+                  NimbleOptions.docs(nested_schema, nest_level: 1)
             ],
             other_key: [type: :string]
           ]

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -1,8 +1,8 @@
 defmodule NimbleOptions.Docs do
   @moduledoc false
 
-  def generate(schema) when is_list(schema) do
-    {docs, sections, _level} = build_docs(schema, {[], [], 0})
+  def generate(schema, nest_levels) when is_list(schema) do
+    {docs, sections, _level} = build_docs(schema, {[], [], nest_levels})
     to_string([Enum.reverse(docs), Enum.reverse(sections)])
   end
 

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -2,8 +2,8 @@ defmodule NimbleOptions.Docs do
   @moduledoc false
 
   def generate(schema, options) when is_list(schema) and is_list(options) do
-    nest_levels = Keyword.get(options, :nest_levels, 0)
-    {docs, sections, _level} = build_docs(schema, {[], [], nest_levels})
+    nest_level = Keyword.get(options, :nest_level, 0)
+    {docs, sections, _level} = build_docs(schema, {[], [], nest_level})
     to_string([Enum.reverse(docs), Enum.reverse(sections)])
   end
 

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -1,7 +1,8 @@
 defmodule NimbleOptions.Docs do
   @moduledoc false
 
-  def generate(schema, nest_levels) when is_list(schema) do
+  def generate(schema, options) when is_list(schema) and is_list(options) do
+    nest_levels = Keyword.get(options, :nest_levels, 0)
     {docs, sections, _level} = build_docs(schema, {[], [], nest_levels})
     to_string([Enum.reverse(docs), Enum.reverse(sections)])
   end

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -1237,6 +1237,38 @@ defmodule NimbleOptionsTest do
       assert NimbleOptions.docs(schema) == docs
     end
 
+    test "passing specific indentation" do
+      nested_schema = [
+        allowed_messages: [type: :pos_integer, doc: "Allowed messages."],
+        interval: [type: :pos_integer, doc: "Interval."]
+      ]
+
+      schema = [
+        producer: [
+          type: {:or, [:string, keyword_list: nested_schema]},
+          doc: """
+          The producer. Either a string or a keyword list with the following keys:
+
+          #{NimbleOptions.docs(nested_schema, _nest_levels = 1)}
+          """
+        ],
+        other_key: [type: :string]
+      ]
+
+      docs = """
+        * `:producer` - The producer. Either a string or a keyword list with the following keys:
+
+          * `:allowed_messages` - Allowed messages.
+
+          * `:interval` - Interval.
+
+        * `:other_key`
+
+      """
+
+      assert NimbleOptions.docs(schema) == docs
+    end
+
     test "generate subsections for nested options" do
       schema = [
         name: [required: true, type: :atom, doc: "The name."],

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -1249,7 +1249,7 @@ defmodule NimbleOptionsTest do
           doc: """
           The producer. Either a string or a keyword list with the following keys:
 
-          #{NimbleOptions.docs(nested_schema, _nest_levels = 1)}
+          #{NimbleOptions.docs(nested_schema, nest_levels: 1)}
           """
         ],
         other_key: [type: :string]

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -1249,7 +1249,7 @@ defmodule NimbleOptionsTest do
           doc: """
           The producer. Either a string or a keyword list with the following keys:
 
-          #{NimbleOptions.docs(nested_schema, nest_levels: 1)}
+          #{NimbleOptions.docs(nested_schema, nest_level: 1)}
           """
         ],
         other_key: [type: :string]


### PR DESCRIPTION
The nesting level allows to nest all options in the generated Markdown by the given level. This allows to have, for example, a nested `nested_schema` schema and use `NimbleOptions.docs/2` inside the documentation for another option:

```elixir
main_schema = [
  my_key: [
    type: {:or, [:string, keyword_list: nested_schema]},
    doc: """
    Either a string or a keyword list with keys:
    
    #{NimbleOptions.docs(nested_schema, _nest_level = 1)}
    """
  ]
]
```

The options for the nested schema in `:my_key` will be nested by one level, producing the correct Markdown.