### PR TITLE
Add float type

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -91,6 +91,8 @@ defmodule NimbleOptions do
 
     * `:pos_integer` - A positive integer.
 
+    * `:float` - A float.
+
     * `:timeout` - A non-negative integer or the atom `:infinity`.
 
     * `:pid` - A PID (process identifier).
@@ -198,6 +200,7 @@ defmodule NimbleOptions do
     :integer,
     :non_neg_integer,
     :pos_integer,
+    :float,
     :mfa,
     :mod_arg,
     :string,
@@ -409,6 +412,10 @@ defmodule NimbleOptions do
       value,
       "expected #{inspect(key)} to be a positive integer, got: #{inspect(value)}"
     )
+  end
+
+  defp validate_type(:float, key, value) when not is_float(value) do
+    error_tuple(key, value, "expected #{inspect(key)} to be a float, got: #{inspect(value)}")
   end
 
   defp validate_type(:atom, key, value) when not is_atom(value) do

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -40,7 +40,7 @@ defmodule NimbleOptionsTest do
       Reason: invalid option type :foo.
 
       Available types: :any, :keyword_list, :non_empty_keyword_list, :atom, \
-      :integer, :non_neg_integer, :pos_integer, :mfa, :mod_arg, :string, :boolean, :timeout, \
+      :integer, :non_neg_integer, :pos_integer, :float, :mfa, :mod_arg, :string, :boolean, :timeout, \
       :pid, {:fun, arity}, {:in, choices}, {:or, subtypes}, {:custom, mod, fun, args}, \
       {:list, subtype} \
       (in options [:stages])\
@@ -283,6 +283,33 @@ defmodule NimbleOptionsTest do
                   key: :min_demand,
                   value: :an_atom,
                   message: "expected :min_demand to be a non negative integer, got: :an_atom"
+                }}
+    end
+
+    test "valid float" do
+      schema = [certainty: [type: :float]]
+      opts = [certainty: 0.5]
+
+      assert NimbleOptions.validate(opts, schema) == {:ok, opts}
+    end
+
+    test "invalid float" do
+      schema = [certainty: [type: :float]]
+
+      assert NimbleOptions.validate([certainty: 1], schema) ==
+               {:error,
+                %ValidationError{
+                  key: :certainty,
+                  value: 1,
+                  message: "expected :certainty to be a float, got: 1"
+                }}
+
+      assert NimbleOptions.validate([certainty: :an_atom], schema) ==
+               {:error,
+                %ValidationError{
+                  key: :certainty,
+                  value: :an_atom,
+                  message: "expected :certainty to be a float, got: :an_atom"
                 }}
     end
 


### PR DESCRIPTION
I was a bit surprised that float is not available as a basic type. So, here it is.