### PR TITLE
use a struct to wrap a valid schema and skip schema validation

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -223,7 +223,6 @@ defmodule NimbleOptions do
   """
 
   alias NimbleOptions.ValidationError
-  alias __MODULE__
 
   defstruct schema: [], schema_valid?: false
 

--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -210,10 +210,7 @@ defmodule NimbleOptions do
       ...> ]
       ...>
       ...> schema = NimbleOptions.new!(raw_schema)
-      ...>
-      ...> config = [hostname: "elixir-lang.org"]
-      ...>
-      ...> NimbleOptions.validate(config, schema)
+      ...> NimbleOptions.validate([hostname: "elixir-lang.org"], schema)
       {:ok, hostname: "elixir-lang.org"}
 
   Calling `new!/1` from a function that receives options will still validate the schema each time
@@ -303,7 +300,7 @@ defmodule NimbleOptions do
 
   If the given schema is not valid, raises a `NimbleOptions.ValidationError`.
   """
-  @spec new!(schema()) :: t() | {:error, ValidationError.t()}
+  @spec new!(schema()) :: t()
   def new!(schema) when is_list(schema) do
     case validate_options_with_schema(schema, options_schema()) do
       {:ok, validated_schema} ->

--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -224,7 +224,7 @@ defmodule NimbleOptions do
 
   alias NimbleOptions.ValidationError
 
-  defstruct schema: [], schema_valid?: false
+  defstruct schema: []
 
   @basic_types [
     :any,
@@ -252,7 +252,7 @@ defmodule NimbleOptions do
   The `NimbleOptions` struct embedding a validated schema. See the
   Validating Schemas section in the module documentation.
   """
-  @type t() :: %NimbleOptions{schema: schema(), schema_valid?: boolean()}
+  @type t() :: %NimbleOptions{schema: schema()}
 
   @doc """
   Validate the given `options` with the given `schema`.
@@ -268,12 +268,8 @@ defmodule NimbleOptions do
   @spec validate(keyword(), schema() | t()) ::
           {:ok, validated_options :: keyword()} | {:error, ValidationError.t()}
 
-  def validate(options, %NimbleOptions{schema: schema, schema_valid?: true}) do
-    validate_options_with_schema(options, schema)
-  end
-
   def validate(options, %NimbleOptions{schema: schema}) do
-    validate(options, schema)
+    validate_options_with_schema(options, schema)
   end
 
   def validate(options, schema) when is_list(options) and is_list(schema) do
@@ -303,7 +299,7 @@ defmodule NimbleOptions do
   def new!(schema) when is_list(schema) do
     case validate_options_with_schema(schema, options_schema()) do
       {:ok, validated_schema} ->
-        %NimbleOptions{schema: validated_schema, schema_valid?: true}
+        %NimbleOptions{schema: validated_schema}
 
       {:error, %ValidationError{} = error} ->
         raise ArgumentError,
@@ -355,8 +351,7 @@ defmodule NimbleOptions do
     NimbleOptions.Docs.generate(schema, options)
   end
 
-  def docs(%NimbleOptions{schema: schema, schema_valid?: true}, options)
-      when is_list(schema) and is_list(options) do
+  def docs(%NimbleOptions{schema: schema}, options) when is_list(options) do
     NimbleOptions.Docs.generate(schema, options)
   end
 

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -71,7 +71,7 @@ defmodule NimbleOptions.Docs do
   end
 
   defp get_required_str(schema) do
-    schema[:required] && "Required."
+    (schema[:required] && "Required.") || nil
   end
 
   defp get_default_str(schema) do

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -71,7 +71,7 @@ defmodule NimbleOptions.Docs do
   end
 
   defp get_required_str(schema) do
-    (schema[:required] && "Required.") || nil
+    if schema[:required], do: "Required."
   end
 
   defp get_default_str(schema) do

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -1560,21 +1560,7 @@ defmodule NimbleOptionsTest do
       invalid_schema = [{"a_binary_key", []}]
       invalid_struct = %NimbleOptions{schema: invalid_schema}
 
-      # support elixir 1.6
-      try do
-        NimbleOptions.validate([], invalid_struct)
-        flunk("invalid schema was used to validate options")
-      rescue
-        e in FunctionClauseError ->
-          assert Exception.message(e) ==
-                   "no function clause matching in Keyword.has_key?/2"
-
-        e in ArgumentError ->
-          assert Exception.message(e) == """
-                 expected a keyword list, but an entry in the list is not a two-element \
-                 tuple with an atom as its first element, got: {"a_binary_key", []}\
-                 """
-      end
+      assert catch_error(NimbleOptions.validate([], invalid_struct))
     end
 
     test "can be built at compile time" do


### PR DESCRIPTION
See https://github.com/dashbitco/nimble_options/issues/69

This change makes possible to obtain a valid schema, and then validate options directly without validating the schema itself whenever options are to be validated.

I defined the struct directly in the NimbleOptions module, instead of creating a NimbleOptions.Schema module, because from there, I guess a couple options could be added to the struct, that would be passed into the validation, if someday `validate/2` becomes `validate/3` and support validation options.

(this is also why the flag is called `schema_valid?` and not just `valid?`)

Have a nice day :)