### PR TITLE
add `Range` support for `{:in, choices}` type

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -106,9 +106,9 @@ defmodule NimbleOptions do
     * `{:fun, arity}` - Any function with the specified arity.
 
     * `{:in, choices}` - A value that is a member of one of the `choices`. `choices`
-      should be a list of terms. The value is an element in said list of terms,
-      that is, `value in choices` is `true`. This was previously called `:one_of` and
-      the `:in` name is available since version 0.3.3.
+      should be a list of terms or a `Range`. The value is an element in said
+      list of terms, that is, `value in choices` is `true`. This was previously
+      called `:one_of` and the `:in` name is available since version 0.3.3.
 
     * `{:custom, mod, fun, args}` - A custom type. The related value must be validated
       by `mod.fun(values, ...args)`. The function should return `{:ok, value}` or
@@ -724,6 +724,10 @@ defmodule NimbleOptions do
   end
 
   def validate_type({:in, choices} = value) when is_list(choices) do
+    {:ok, value}
+  end
+
+  def validate_type({:in, _first.._last} = value) do
     {:ok, value}
   end
 

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -572,6 +572,19 @@ defmodule NimbleOptionsTest do
       assert NimbleOptions.validate(opts, schema) == {:ok, opts}
     end
 
+    test "valid {:in, choices} with Range" do
+      schema = [decimals: [type: {:in, 0..255}]]
+
+      opts = [decimals: 0]
+      assert NimbleOptions.validate(opts, schema) == {:ok, opts}
+
+      opts = [decimals: 100]
+      assert NimbleOptions.validate(opts, schema) == {:ok, opts}
+
+      opts = [decimals: 255]
+      assert NimbleOptions.validate(opts, schema) == {:ok, opts}
+    end
+
     test "invalid {:in, choices}" do
       schema = [batch_mode: [type: {:in, [:flush, :bulk]}]]
 
@@ -583,6 +596,20 @@ defmodule NimbleOptionsTest do
                   key: :batch_mode,
                   value: :invalid,
                   message: "expected :batch_mode to be one of [:flush, :bulk], got: :invalid"
+                }}
+    end
+
+    test "invalid {:in, choices} with Range" do
+      schema = [decimals: [type: {:in, 0..255}]]
+
+      opts = [decimals: -1]
+
+      assert NimbleOptions.validate(opts, schema) ==
+               {:error,
+                %ValidationError{
+                  key: :decimals,
+                  value: -1,
+                  message: "expected :decimals to be one of 0..255, got: -1"
                 }}
     end
 


### PR DESCRIPTION
Ranges implement Enumerable and support `in`, so you should be able to
use them with the `{:in, choices}` type.

For example, to check if a value is a byte:

```elixir
schema = [decimals: [type: {:in, 0..255}]]
```

This commit adds that support.