### PR TITLE
Delete the renamed key when using :rename_to

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -411,8 +411,16 @@ defmodule NimbleOptions do
         {:halt, result}
 
       {:ok, value} ->
-        actual_key = schema_opts[:rename_to] || key
-        {:cont, Keyword.update(opts, actual_key, value, fn _ -> value end)}
+        if renamed_key = schema_opts[:rename_to] do
+          opts =
+            opts
+            |> Keyword.update(renamed_key, value, fn _ -> value end)
+            |> Keyword.delete(key)
+
+          {:cont, opts}
+        else
+          {:cont, Keyword.update(opts, key, value, fn _ -> value end)}
+        end
 
       :no_value ->
         if Keyword.has_key?(schema_opts, :default) do

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -141,11 +141,14 @@ defmodule NimbleOptionsTest do
   end
 
   describe ":rename_to" do
-    test "renames option when true" do
-      schema = [context: [rename_to: :new_context], new_context: []]
+    test "renames option and removes the old option" do
+      schema = [
+        port: [rename_to: :new_port],
+        new_port: [type: {:custom, __MODULE__, :string_to_integer, []}]
+      ]
 
-      assert NimbleOptions.validate([context: :ok], schema) ==
-               {:ok, [{:context, :ok}, {:new_context, :ok}]}
+      assert NimbleOptions.validate([port: "4000"], schema) ==
+               {:ok, [new_port: 4000]}
     end
 
     test "is ignored when option is not present given" do


### PR DESCRIPTION
Closes #67.