### PR TITLE
include changelog in docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,8 @@ defmodule NimbleOptions.MixProject do
     [
       main: "NimbleOptions",
       source_ref: "v#{@version}",
-      source_url: @repo_url
+      source_url: @repo_url,
+      extras: ["CHANGELOG.md": [title: "Changelog"]]
     ]
   end
 end


### PR DESCRIPTION
I'm a big fan of being able to check out the lovely changelog notes right from hexdocs, like [in ex_doc](https://hexdocs.pm/ex_doc/changelog.html#content) itself.

What do you think?