### PR TITLE
Fix NimbleOptions.docs/2 type spec

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -346,7 +346,7 @@ defmodule NimbleOptions do
           ]
 
   """
-  @spec docs(schema(), keyword() | t()) :: String.t()
+  @spec docs(schema() | t(), keyword()) :: String.t()
   def docs(schema, options \\ [])
 
   def docs(schema, options) when is_list(schema) and is_list(options) do


### PR DESCRIPTION
`NimbleOptions.docs/2` takes both keyword list and `NimbleOptions` struct as a schema, but the `t/0` type seems to be put in the wrong place by mistake.