### PR TITLE
Add :tuple type

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -131,6 +131,13 @@ defmodule NimbleOptions do
       an updated value, then that updated value is used in the resulting list. Validation
       fails at the *first* element that is invalid according to `subtype`.
 
+    * `{:tuple, tuple_of_subtypes}` - A tuple as described by `tuple_of_subtypes`.
+      `tuple_of_subtypes` must be a tuple itself with the same length as the expected tuple.
+      Each of its elements must be a subtype that should match the given element in that
+      same position. For example, to describe 3-element tuples with an atom, a string, and
+      a list of integers you would use the type `{:tuple, {:atom, :string, {:list, :integer}}}`.
+      *Available since v0.4.1*.
+
   ## Example
 
       iex> schema = [
@@ -676,6 +683,42 @@ defmodule NimbleOptions do
     error_tuple(key, value, "expected #{inspect(key)} to be a list, got: #{inspect(value)}")
   end
 
+  defp validate_type({:tuple, tuple_def}, key, value)
+       when is_tuple(value) and tuple_size(tuple_def) == tuple_size(value) do
+    updated_tuple =
+      tuple_def
+      |> Tuple.to_list()
+      |> Stream.with_index()
+      |> Enum.reduce({}, fn {subtype, index}, acc ->
+        elem = elem(value, index)
+
+        case validate_type(subtype, "tuple element", elem) do
+          {:ok, updated_elem} -> Tuple.append(acc, updated_elem)
+          {:error, %ValidationError{} = error} -> throw({:error, index, error})
+        end
+      end)
+
+    {:ok, updated_tuple}
+  catch
+    {:error, index, %ValidationError{} = error} ->
+      message =
+        "tuple element at position #{index} in #{inspect(key)} failed validation: #{error.message}"
+
+      error_tuple(key, value, message)
+  end
+
+  defp validate_type({:tuple, tuple_def}, key, value) when is_tuple(value) do
+    error_tuple(
+      key,
+      value,
+      "expected #{inspect(key)} to be a tuple with #{tuple_size(tuple_def)} elements, got: #{inspect(value)}"
+    )
+  end
+
+  defp validate_type({:tuple, _tuple_def}, key, value) do
+    error_tuple(key, value, "expected #{inspect(key)} to be a tuple, got: #{inspect(value)}")
+  end
+
   defp validate_type(nil, key, value) do
     validate_type(:any, key, value)
   end
@@ -706,7 +749,8 @@ defmodule NimbleOptions do
           "{:in, choices}",
           "{:or, subtypes}",
           "{:custom, mod, fun, args}",
-          "{:list, subtype}"
+          "{:list, subtype}",
+          "{:tuple, tuple_of_subtypes}"
         ]
 
     Enum.join(types, ", ")
@@ -750,6 +794,23 @@ defmodule NimbleOptions do
       {:ok, validated_subtype} -> {:ok, {:list, validated_subtype}}
       {:error, reason} -> {:error, "invalid subtype for :list type: #{reason}"}
     end
+  end
+
+  def validate_type({:tuple, tuple_def}) do
+    validated_def =
+      tuple_def
+      |> Tuple.to_list()
+      |> Enum.map(fn subtype ->
+        case validate_type(subtype) do
+          {:ok, validated_subtype} -> validated_subtype
+          {:error, reason} -> throw({:error, "invalid subtype for :tuple type: #{reason}"})
+        end
+      end)
+      |> List.to_tuple()
+
+    {:ok, {:tuple, validated_def}}
+  catch
+    {:error, reason} -> {:error, reason}
   end
 
   def validate_type(value) do

--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -131,11 +131,11 @@ defmodule NimbleOptions do
       an updated value, then that updated value is used in the resulting list. Validation
       fails at the *first* element that is invalid according to `subtype`.
 
-    * `{:tuple, tuple_of_subtypes}` - A tuple as described by `tuple_of_subtypes`.
-      `tuple_of_subtypes` must be a tuple itself with the same length as the expected tuple.
-      Each of its elements must be a subtype that should match the given element in that
+    * `{:tuple, list_of_subtypes}` - A tuple as described by `tuple_of_subtypes`.
+      `list_of_subtypes` must be a list with the same length as the expected tuple.
+      Each of the list's elements must be a subtype that should match the given element in that
       same position. For example, to describe 3-element tuples with an atom, a string, and
-      a list of integers you would use the type `{:tuple, {:atom, :string, {:list, :integer}}}`.
+      a list of integers you would use the type `{:tuple, [:atom, :string, {:list, :integer}]}`.
       *Available since v0.4.1*.
 
   ## Example
@@ -684,10 +684,9 @@ defmodule NimbleOptions do
   end
 
   defp validate_type({:tuple, tuple_def}, key, value)
-       when is_tuple(value) and tuple_size(tuple_def) == tuple_size(value) do
+       when is_tuple(value) and length(tuple_def) == tuple_size(value) do
     updated_tuple =
       tuple_def
-      |> Tuple.to_list()
       |> Stream.with_index()
       |> Enum.reduce({}, fn {subtype, index}, acc ->
         elem = elem(value, index)
@@ -711,7 +710,7 @@ defmodule NimbleOptions do
     error_tuple(
       key,
       value,
-      "expected #{inspect(key)} to be a tuple with #{tuple_size(tuple_def)} elements, got: #{inspect(value)}"
+      "expected #{inspect(key)} to be a tuple with #{length(tuple_def)} elements, got: #{inspect(value)}"
     )
   end
 
@@ -750,7 +749,7 @@ defmodule NimbleOptions do
           "{:or, subtypes}",
           "{:custom, mod, fun, args}",
           "{:list, subtype}",
-          "{:tuple, tuple_of_subtypes}"
+          "{:tuple, list_of_subtypes}"
         ]
 
     Enum.join(types, ", ")
@@ -796,17 +795,14 @@ defmodule NimbleOptions do
     end
   end
 
-  def validate_type({:tuple, tuple_def}) do
+  def validate_type({:tuple, tuple_def}) when is_list(tuple_def) do
     validated_def =
-      tuple_def
-      |> Tuple.to_list()
-      |> Enum.map(fn subtype ->
+      Enum.map(tuple_def, fn subtype ->
         case validate_type(subtype) do
           {:ok, validated_subtype} -> validated_subtype
           {:error, reason} -> throw({:error, "invalid subtype for :tuple type: #{reason}"})
         end
       end)
-      |> List.to_tuple()
 
     {:ok, {:tuple, validated_def}}
   catch

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -42,7 +42,7 @@ defmodule NimbleOptionsTest do
       Available types: :any, :keyword_list, :non_empty_keyword_list, :atom, \
       :integer, :non_neg_integer, :pos_integer, :float, :mfa, :mod_arg, :string, :boolean, :timeout, \
       :pid, {:fun, arity}, {:in, choices}, {:or, subtypes}, {:custom, mod, fun, args}, \
-      {:list, subtype}, {:tuple, tuple_of_subtypes} \
+      {:list, subtype}, {:tuple, list_of_subtypes} \
       (in options [:stages])\
       """
 
@@ -951,7 +951,7 @@ defmodule NimbleOptionsTest do
     end
 
     test "valid {:tuple, tuple_def}" do
-      schema = [result: [type: {:tuple, {{:in, [:ok, :error]}, :string}}]]
+      schema = [result: [type: {:tuple, [{:in, [:ok, :error]}, :string]}]]
 
       opts = [result: {:ok, "it worked"}]
       assert NimbleOptions.validate(opts, schema) == {:ok, opts}
@@ -961,7 +961,7 @@ defmodule NimbleOptionsTest do
     end
 
     test "invalid {:tuple, tuple_def}" do
-      schema = [result: [type: {:tuple, {{:in, [:ok, :error]}, :string}}]]
+      schema = [result: [type: {:tuple, [{:in, [:ok, :error]}, :string]}]]
 
       # Not a list
       opts = [result: "not a tuple"]
@@ -994,7 +994,7 @@ defmodule NimbleOptionsTest do
              }
 
       # Nested list with invalid elements
-      schema = [tup: [type: {:tuple, {{:tuple, {:string, :string}}, :integer}}]]
+      schema = [tup: [type: {:tuple, [{:tuple, [:string, :string]}, :integer]}]]
       opts = [tup: {{"string", :not_a_string}, 1}]
 
       message = """


### PR DESCRIPTION
See docs below. I think it's a pretty nice addition and a fairly common scenario. For example, Xandra [would use it for a custom `{module, options}` tuple](https://github.com/lexhide/xandra/pull/209/files#diff-b4759000fcc9c0a5bf4b63a2cf875a6a4d6ee7844133cee728d238bc1bc6bef8R224-R225).