### PR TITLE
Add the :reference option type

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -100,6 +100,8 @@ defmodule NimbleOptions do
 
     * `:pid` - A PID (process identifier).
 
+    * `:reference` - A reference (see `t:reference/0`).
+
     * `:mfa` - A named function in the format `{module, function, arity}` where
       `arity` is a list of arguments. For example, `{MyModule, :my_fun, [arg1, arg2]}`.
 
@@ -253,7 +255,8 @@ defmodule NimbleOptions do
     :string,
     :boolean,
     :timeout,
-    :pid
+    :pid,
+    :reference
   ]
 
   @typedoc """
@@ -552,6 +555,14 @@ defmodule NimbleOptions do
 
   defp validate_type(:pid, key, value) do
     error_tuple(key, value, "expected #{inspect(key)} to be a pid, got: #{inspect(value)}")
+  end
+
+  defp validate_type(:reference, _key, value) when is_reference(value) do
+    {:ok, value}
+  end
+
+  defp validate_type(:reference, key, value) do
+    error_tuple(key, value, "expected #{inspect(key)} to be a reference, got: #{inspect(value)}")
   end
 
   defp validate_type(:mfa, _key, {mod, fun, args} = value)

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -41,7 +41,7 @@ defmodule NimbleOptionsTest do
 
       Available types: :any, :keyword_list, :non_empty_keyword_list, :atom, \
       :integer, :non_neg_integer, :pos_integer, :float, :mfa, :mod_arg, :string, :boolean, :timeout, \
-      :pid, {:fun, arity}, {:in, choices}, {:or, subtypes}, {:custom, mod, fun, args}, \
+      :pid, :reference, {:fun, arity}, {:in, choices}, {:or, subtypes}, {:custom, mod, fun, args}, \
       {:list, subtype}, {:tuple, list_of_subtypes} \
       (in options [:stages])\
       """
@@ -434,6 +434,24 @@ defmodule NimbleOptionsTest do
                   key: :name,
                   value: 1,
                   message: "expected :name to be a pid, got: 1"
+                }}
+    end
+
+    test "valid reference" do
+      schema = [name: [type: :reference]]
+      opts = [name: make_ref()]
+      assert NimbleOptions.validate(opts, schema) == {:ok, opts}
+    end
+
+    test "invalid reference" do
+      schema = [name: [type: :reference]]
+
+      assert NimbleOptions.validate([name: 1], schema) ==
+               {:error,
+                %ValidationError{
+                  key: :name,
+                  value: 1,
+                  message: "expected :name to be a reference, got: 1"
                 }}
     end
 


### PR DESCRIPTION
I think once we support `:pid`, it makes sense to support `:reference` too. I have an actual use case too, for some internal option validation in Xandra :smile: