### PR TITLE
Add types to autogenerated schema docs

### DIFF
--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -105,7 +105,7 @@ defmodule NimbleOptions.Docs do
       {:non_empty_keyword_list, _} ->
         "non-empty keyword list"
 
-      {:or, values} ->
+      {:or, _values} ->
         nil
 
       :keyword_list ->

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -91,7 +91,7 @@ defmodule NimbleOptions.Docs do
       {:fun, arity} ->
         "function of arity #{arity}"
 
-      {:keyword_list, _} ->
+      {:keyword_list, _keys} ->
         "keyword list"
 
       {:in, values} ->
@@ -114,7 +114,21 @@ defmodule NimbleOptions.Docs do
       :non_empty_keyword_list ->
         "non-empty keyword list"
 
-      _type ->
+      type
+      when type in [
+             :any,
+             :atom,
+             :boolean,
+             :integer,
+             :mfa,
+             :mod_arg,
+             :non_neg_integer,
+             :pid,
+             :pos_integer,
+             :float,
+             :timeout,
+             :string
+           ] ->
         String.trim(to_string(schema[:type]))
     end
   end

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -95,7 +95,7 @@ defmodule NimbleOptions.Docs do
         "keyword list"
 
       {:in, values} ->
-        "one of " <> Enum.map_join(values, ", ", &get_type_str(type: &1))
+        "one of #{inspect(values)}"
 
       {:list, subtype} ->
         if subtype_str = get_type_str(type: subtype) do

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -106,7 +106,7 @@ defmodule NimbleOptions.Docs do
         "non-empty keyword list"
 
       {:or, values} ->
-        Enum.map_join(values, " or ", &get_type_str(type: &1))
+        nil
 
       :keyword_list ->
         "keyword list"

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -98,7 +98,7 @@ defmodule NimbleOptions.Docs do
         "one of " <> Enum.map_join(values, ", ", &get_type_str(type: &1))
 
       {:list, subtype} ->
-        if subtype_str = get_type_str(subtype) do
+        if subtype_str = get_type_str(type: subtype) do
           "list of #{subtype_str}"
         end
 

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -42,7 +42,6 @@ defmodule NimbleOptions.Docs do
   defp option_doc({key, schema}, {docs, sections, level}) do
     description =
       [
-        get_type_str(schema),
         get_required_str(schema),
         get_doc_str(schema),
         get_default_str(schema)
@@ -54,8 +53,8 @@ defmodule NimbleOptions.Docs do
       end
 
     indent = String.duplicate("  ", level)
-
-    doc = indent_doc("  * `#{inspect(key)}`#{description}\n\n", indent)
+    type = if type = get_type_str(schema), do: " (#{type})", else: ""
+    doc = indent_doc("  * `#{inspect(key)}`#{type}#{description}\n\n", indent)
 
     docs = [doc | docs]
 
@@ -87,18 +86,34 @@ defmodule NimbleOptions.Docs do
 
   defp get_type_str(schema) do
     case schema[:type] do
-      nil -> nil
-      {:custom, _module, _function, _args} -> nil
-      {:fun, arity} -> "function of arity #{arity}"
-      {:keyword_list, _} -> "keyword list"
-      {:in, values} -> "one of " <> Enum.map_join(values, ", ", &get_type_str(type: &1))
+      nil ->
+        nil
+
+      {:custom, _module, _function, _args} ->
+        nil
+
+      {:fun, arity} ->
+        "function of arity #{arity}"
+
+      {:keyword_list, _} ->
+        "keyword list"
+
+      {:in, values} ->
+        "one of " <> Enum.map_join(values, ", ", &get_type_str(type: &1))
+
       {:list, subtype} ->
         if subtype_str = get_type_str(subtype) do
-          "list of subtype_str"
+          "list of #{subtype_str}"
         end
-      {:non_empty_keyword_list, _} -> "non-empty keyword list"
-      {:or, values} -> Enum.map_join(values, " or ", &get_type_str(type: &1))
-      _type -> String.trim(to_string(schema[:type]))
+
+      {:non_empty_keyword_list, _} ->
+        "non-empty keyword list"
+
+      {:or, values} ->
+        Enum.map_join(values, " or ", &get_type_str(type: &1))
+
+      _type ->
+        String.trim(to_string(schema[:type]))
     end
   end
 

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -89,7 +89,7 @@ defmodule NimbleOptions.Docs do
     case schema[:type] do
       nil -> nil
       {:custom, _module, _function, _args} -> nil
-      {:fun, arity} -> "function/#{arity}"
+      {:fun, arity} -> "function of arity #{arity}"
       {:keyword_list, _} -> "keyword list"
       {:in, values} -> "one of " <> Enum.map_join(values, ", ", &get_type_str(type: &1))
       {:list, subtype} ->

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -42,6 +42,8 @@ defmodule NimbleOptions.Docs do
   defp option_doc({key, schema}, {docs, sections, level}) do
     description =
       [
+        get_type_str(schema),
+        get_required_str(schema),
         get_doc_str(schema),
         get_default_str(schema)
       ]
@@ -53,16 +55,7 @@ defmodule NimbleOptions.Docs do
 
     indent = String.duplicate("  ", level)
 
-    type =
-      if schema[:type] do
-        required = get_required_str(schema)
-        type = get_type_str(schema)
-        " (#{required}#{type})"
-      else
-        ""
-      end
-
-    doc = indent_doc("  * `#{inspect(key)}`#{type}#{description}\n\n", indent)
+    doc = indent_doc("  * `#{inspect(key)}`#{description}\n\n", indent)
 
     docs = [doc | docs]
 
@@ -84,25 +77,25 @@ defmodule NimbleOptions.Docs do
   end
 
   defp get_required_str(schema) do
-    if schema[:required], do: "required ", else: ""
+    if schema[:required], do: "Required."
   end
 
   defp get_default_str(schema) do
-    if Keyword.has_key?(schema, :default) do
-      "The default value is `#{inspect(schema[:default])}`."
-    end
+    if Keyword.has_key?(schema, :default),
+      do: "The default value is `#{inspect(schema[:default])}`."
   end
 
   defp get_type_str(schema) do
     case schema[:type] do
-      {:custom, _module, _function, _args} -> "`custom`"
-      {:fun, arity} -> "`function/#{arity}`"
-      {:keyword_list, _} -> "`keyword`"
-      {:in, values} -> "one of `" <> Enum.map_join(values, "`, `", &get_type_str(type: &1)) <> "`"
-      {:list, subtype} -> "`list(#{subtype})`"
-      {:non_empty_keyword_list, _} -> "`keyword`"
+      nil -> nil
+      {:custom, _module, _function, _args} -> nil
+      {:fun, arity} -> "function/#{arity}"
+      {:keyword_list, _} -> "keyword"
+      {:in, values} -> "one of " <> Enum.map_join(values, ", ", &get_type_str(type: &1))
+      {:list, subtype} -> "list(#{subtype})"
+      {:non_empty_keyword_list, _} -> "keyword"
       {:or, values} -> Enum.map_join(values, " or ", &get_type_str(type: &1))
-      _type -> "`" <> String.trim(to_string(schema[:type])) <> "`"
+      _type -> String.trim(to_string(schema[:type]))
     end
   end
 

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -92,7 +92,10 @@ defmodule NimbleOptions.Docs do
       {:fun, arity} -> "function/#{arity}"
       {:keyword_list, _} -> "keyword"
       {:in, values} -> "one of " <> Enum.map_join(values, ", ", &get_type_str(type: &1))
-      {:list, subtype} -> "list(#{subtype})"
+      {:list, subtype} ->
+        if subtype_str = get_type_str(subtype) do
+          "list of subtype_str"
+        end
       {:non_empty_keyword_list, _} -> "keyword"
       {:or, values} -> Enum.map_join(values, " or ", &get_type_str(type: &1))
       _type -> String.trim(to_string(schema[:type]))

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -96,7 +96,7 @@ defmodule NimbleOptions.Docs do
         if subtype_str = get_type_str(subtype) do
           "list of subtype_str"
         end
-      {:non_empty_keyword_list, _} -> "keyword"
+      {:non_empty_keyword_list, _} -> "non-empty keyword list"
       {:or, values} -> Enum.map_join(values, " or ", &get_type_str(type: &1))
       _type -> String.trim(to_string(schema[:type]))
     end

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -90,7 +90,7 @@ defmodule NimbleOptions.Docs do
       nil -> nil
       {:custom, _module, _function, _args} -> nil
       {:fun, arity} -> "function/#{arity}"
-      {:keyword_list, _} -> "keyword"
+      {:keyword_list, _} -> "keyword list"
       {:in, values} -> "one of " <> Enum.map_join(values, ", ", &get_type_str(type: &1))
       {:list, subtype} ->
         if subtype_str = get_type_str(subtype) do

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -41,11 +41,7 @@ defmodule NimbleOptions.Docs do
 
   defp option_doc({key, schema}, {docs, sections, level}) do
     description =
-      [
-        get_required_str(schema),
-        get_doc_str(schema),
-        get_default_str(schema)
-      ]
+      [get_required_str(schema), get_doc_str(schema), get_default_str(schema)]
       |> Enum.reject(&is_nil/1)
       |> case do
         [] -> ""

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -112,6 +112,12 @@ defmodule NimbleOptions.Docs do
       {:or, values} ->
         Enum.map_join(values, " or ", &get_type_str(type: &1))
 
+      :keyword_list ->
+        "keyword list"
+
+      :non_empty_keyword_list ->
+        "non-empty keyword list"
+
       _type ->
         String.trim(to_string(schema[:type]))
     end

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -1460,11 +1460,11 @@ defmodule NimbleOptionsTest do
   describe "NimbleOptions.docs/1" do
     test "override docs for recursive keys" do
       docs = """
-        * `:type` (required `atom`) - The type of the option item.
+        * `:type` - atom Required. The type of the option item.
 
-        * `:required` (`boolean`) - Defines if the option item is required. The default value is `false`.
+        * `:required` - boolean Defines if the option item is required. The default value is `false`.
 
-        * `:keys` (`keyword_list`) - Defines which set of keys are accepted.
+        * `:keys` - keyword_list Defines which set of keys are accepted.
 
         * `:default` - The default.
 
@@ -1496,17 +1496,17 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:producer` (`non_empty_keyword_list`) - The producer. Supported options:
+        * `:producer` - non_empty_keyword_list The producer. Supported options:
 
-          * `:module` (`mod_arg`) - The module.
+          * `:module` - mod_arg The module.
 
-          * `:rate_limiting` (`non_empty_keyword_list`) - A list of options to enable and configure rate limiting. Supported options:
+          * `:rate_limiting` - non_empty_keyword_list A list of options to enable and configure rate limiting. Supported options:
 
-            * `:allowed_messages` (`pos_integer`) - Number of messages per interval.
+            * `:allowed_messages` - pos_integer Number of messages per interval.
 
-            * `:interval` (required `pos_integer`) - The interval.
+            * `:interval` - pos_integer Required. The interval.
 
-        * `:other_key` (`string`)
+        * `:other_key` - string
 
       """
 
@@ -1533,13 +1533,13 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:producer` (`string` or `keyword`) - The producer. Either a string or a keyword list with the following keys:
+        * `:producer` - string or keyword The producer. Either a string or a keyword list with the following keys:
 
-          * `:allowed_messages` (`pos_integer`) - Allowed messages.
+          * `:allowed_messages` - pos_integer Allowed messages.
 
-          * `:interval` (`pos_integer`) - Interval.
+          * `:interval` - pos_integer Interval.
 
-        * `:other_key` (`string`)
+        * `:other_key` - string
 
       """
 
@@ -1568,11 +1568,11 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:name` (required `atom`) - The name.
+        * `:name` - atom Required. The name.
 
-        * `:producer` (`non_empty_keyword_list`) - This is the producer summary. See "Producers options" section below.
+        * `:producer` - non_empty_keyword_list This is the producer summary. See "Producers options" section below.
 
-        * `:other_key` (`string`)
+        * `:other_key` - string
 
       ### Producers options
 
@@ -1580,9 +1580,9 @@ defmodule NimbleOptionsTest do
 
       The available options are:
 
-        * `:module` (`mod_arg`) - The module.
+        * `:module` - mod_arg The module.
 
-        * `:concurrency` (`pos_integer`) - The concurrency.
+        * `:concurrency` - pos_integer The concurrency.
 
       """
 
@@ -1608,13 +1608,13 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:name` (`string`) - The name.
+        * `:name` - string The name.
 
       This a multiline text.
 
       Another line.
 
-        * `:module` (`atom`) - The module.
+        * `:module` - atom The module.
 
       """
 
@@ -1629,9 +1629,9 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:name` (`atom`) - An atom.
+        * `:name` - atom An atom.
 
-        * `:count` (`integer`)
+        * `:count` - integer
 
       """
 
@@ -1670,7 +1670,7 @@ defmodule NimbleOptionsTest do
       assert {:ok, ^opts} = NimbleOptions.validate(opts, schema)
 
       assert NimbleOptions.docs(schema) == """
-               * `:custom_keys` (`keyword_list`) - Custom keys
+               * `:custom_keys` - keyword_list Custom keys
 
              """
     end

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -1464,7 +1464,7 @@ defmodule NimbleOptionsTest do
 
         * `:required` (boolean) - Defines if the option item is required. The default value is `false`.
 
-        * `:keys` (keyword_list) - Defines which set of keys are accepted.
+        * `:keys` (keyword list) - Defines which set of keys are accepted.
 
         * `:default` - The default.
 
@@ -1496,11 +1496,11 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:producer` (non_empty_keyword_list) - The producer. Supported options:
+        * `:producer` (non-empty keyword list) - The producer. Supported options:
 
           * `:module` (mod_arg) - The module.
 
-          * `:rate_limiting` (non_empty_keyword_list) - A list of options to enable and configure rate limiting. Supported options:
+          * `:rate_limiting` (non-empty keyword list) - A list of options to enable and configure rate limiting. Supported options:
 
             * `:allowed_messages` (pos_integer) - Number of messages per interval.
 
@@ -1570,7 +1570,7 @@ defmodule NimbleOptionsTest do
       docs = """
         * `:name` (atom) - Required. The name.
 
-        * `:producer` (non_empty_keyword_list) - This is the producer summary. See "Producers options" section below.
+        * `:producer` (non-empty keyword list) - This is the producer summary. See "Producers options" section below.
 
         * `:other_key` (string)
 
@@ -1670,7 +1670,7 @@ defmodule NimbleOptionsTest do
       assert {:ok, ^opts} = NimbleOptions.validate(opts, schema)
 
       assert NimbleOptions.docs(schema) == """
-               * `:custom_keys` (keyword_list) - Custom keys
+               * `:custom_keys` (keyword list) - Custom keys
 
              """
     end

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -1460,11 +1460,11 @@ defmodule NimbleOptionsTest do
   describe "NimbleOptions.docs/1" do
     test "override docs for recursive keys" do
       docs = """
-        * `:type` - atom Required. The type of the option item.
+        * `:type` (atom) - Required. The type of the option item.
 
-        * `:required` - boolean Defines if the option item is required. The default value is `false`.
+        * `:required` (boolean) - Defines if the option item is required. The default value is `false`.
 
-        * `:keys` - keyword_list Defines which set of keys are accepted.
+        * `:keys` (keyword_list) - Defines which set of keys are accepted.
 
         * `:default` - The default.
 
@@ -1496,17 +1496,17 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:producer` - non_empty_keyword_list The producer. Supported options:
+        * `:producer` (non_empty_keyword_list) - The producer. Supported options:
 
-          * `:module` - mod_arg The module.
+          * `:module` (mod_arg) - The module.
 
-          * `:rate_limiting` - non_empty_keyword_list A list of options to enable and configure rate limiting. Supported options:
+          * `:rate_limiting` (non_empty_keyword_list) - A list of options to enable and configure rate limiting. Supported options:
 
-            * `:allowed_messages` - pos_integer Number of messages per interval.
+            * `:allowed_messages` (pos_integer) - Number of messages per interval.
 
-            * `:interval` - pos_integer Required. The interval.
+            * `:interval` (pos_integer) - Required. The interval.
 
-        * `:other_key` - string
+        * `:other_key` (string)
 
       """
 
@@ -1533,13 +1533,13 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:producer` - string or keyword The producer. Either a string or a keyword list with the following keys:
+        * `:producer` (string or keyword list) - The producer. Either a string or a keyword list with the following keys:
 
-          * `:allowed_messages` - pos_integer Allowed messages.
+          * `:allowed_messages` (pos_integer) - Allowed messages.
 
-          * `:interval` - pos_integer Interval.
+          * `:interval` (pos_integer) - Interval.
 
-        * `:other_key` - string
+        * `:other_key` (string)
 
       """
 
@@ -1568,11 +1568,11 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:name` - atom Required. The name.
+        * `:name` (atom) - Required. The name.
 
-        * `:producer` - non_empty_keyword_list This is the producer summary. See "Producers options" section below.
+        * `:producer` (non_empty_keyword_list) - This is the producer summary. See "Producers options" section below.
 
-        * `:other_key` - string
+        * `:other_key` (string)
 
       ### Producers options
 
@@ -1580,9 +1580,9 @@ defmodule NimbleOptionsTest do
 
       The available options are:
 
-        * `:module` - mod_arg The module.
+        * `:module` (mod_arg) - The module.
 
-        * `:concurrency` - pos_integer The concurrency.
+        * `:concurrency` (pos_integer) - The concurrency.
 
       """
 
@@ -1608,13 +1608,13 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:name` - string The name.
+        * `:name` (string) - The name.
 
       This a multiline text.
 
       Another line.
 
-        * `:module` - atom The module.
+        * `:module` (atom) - The module.
 
       """
 
@@ -1629,9 +1629,9 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:name` - atom An atom.
+        * `:name` (atom) - An atom.
 
-        * `:count` - integer
+        * `:count` (integer)
 
       """
 
@@ -1670,7 +1670,7 @@ defmodule NimbleOptionsTest do
       assert {:ok, ^opts} = NimbleOptions.validate(opts, schema)
 
       assert NimbleOptions.docs(schema) == """
-               * `:custom_keys` - keyword_list Custom keys
+               * `:custom_keys` (keyword_list) - Custom keys
 
              """
     end

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -1460,11 +1460,11 @@ defmodule NimbleOptionsTest do
   describe "NimbleOptions.docs/1" do
     test "override docs for recursive keys" do
       docs = """
-        * `:type` - Required. The type of the option item.
+        * `:type` (required `atom`) - The type of the option item.
 
-        * `:required` - Defines if the option item is required. The default value is `false`.
+        * `:required` (`boolean`) - Defines if the option item is required. The default value is `false`.
 
-        * `:keys` - Defines which set of keys are accepted.
+        * `:keys` (`keyword_list`) - Defines which set of keys are accepted.
 
         * `:default` - The default.
 
@@ -1496,17 +1496,17 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:producer` - The producer. Supported options:
+        * `:producer` (`non_empty_keyword_list`) - The producer. Supported options:
 
-          * `:module` - The module.
+          * `:module` (`mod_arg`) - The module.
 
-          * `:rate_limiting` - A list of options to enable and configure rate limiting. Supported options:
+          * `:rate_limiting` (`non_empty_keyword_list`) - A list of options to enable and configure rate limiting. Supported options:
 
-            * `:allowed_messages` - Number of messages per interval.
+            * `:allowed_messages` (`pos_integer`) - Number of messages per interval.
 
-            * `:interval` - Required. The interval.
+            * `:interval` (required `pos_integer`) - The interval.
 
-        * `:other_key`
+        * `:other_key` (`string`)
 
       """
 
@@ -1533,13 +1533,13 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:producer` - The producer. Either a string or a keyword list with the following keys:
+        * `:producer` (`string` or `keyword`) - The producer. Either a string or a keyword list with the following keys:
 
-          * `:allowed_messages` - Allowed messages.
+          * `:allowed_messages` (`pos_integer`) - Allowed messages.
 
-          * `:interval` - Interval.
+          * `:interval` (`pos_integer`) - Interval.
 
-        * `:other_key`
+        * `:other_key` (`string`)
 
       """
 
@@ -1568,11 +1568,11 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:name` - Required. The name.
+        * `:name` (required `atom`) - The name.
 
-        * `:producer` - This is the producer summary. See "Producers options" section below.
+        * `:producer` (`non_empty_keyword_list`) - This is the producer summary. See "Producers options" section below.
 
-        * `:other_key`
+        * `:other_key` (`string`)
 
       ### Producers options
 
@@ -1580,9 +1580,9 @@ defmodule NimbleOptionsTest do
 
       The available options are:
 
-        * `:module` - The module.
+        * `:module` (`mod_arg`) - The module.
 
-        * `:concurrency` - The concurrency.
+        * `:concurrency` (`pos_integer`) - The concurrency.
 
       """
 
@@ -1608,13 +1608,13 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:name` - The name.
+        * `:name` (`string`) - The name.
 
       This a multiline text.
 
       Another line.
 
-        * `:module` - The module.
+        * `:module` (`atom`) - The module.
 
       """
 
@@ -1629,9 +1629,9 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:name` - An atom.
+        * `:name` (`atom`) - An atom.
 
-        * `:count`
+        * `:count` (`integer`)
 
       """
 
@@ -1670,7 +1670,7 @@ defmodule NimbleOptionsTest do
       assert {:ok, ^opts} = NimbleOptions.validate(opts, schema)
 
       assert NimbleOptions.docs(schema) == """
-               * `:custom_keys` - Custom keys
+               * `:custom_keys` (`keyword_list`) - Custom keys
 
              """
     end

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -1533,7 +1533,7 @@ defmodule NimbleOptionsTest do
       ]
 
       docs = """
-        * `:producer` (string or keyword list) - The producer. Either a string or a keyword list with the following keys:
+        * `:producer` - The producer. Either a string or a keyword list with the following keys:
 
           * `:allowed_messages` (pos_integer) - Allowed messages.
 

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -1529,7 +1529,7 @@ defmodule NimbleOptionsTest do
           #{NimbleOptions.docs(nested_schema, nest_level: 1)}
           """
         ],
-        other_key: [type: :string]
+        other_key: [type: {:list, :atom}]
       ]
 
       docs = """
@@ -1539,7 +1539,7 @@ defmodule NimbleOptionsTest do
 
           * `:interval` (pos_integer) - Interval.
 
-        * `:other_key` (string)
+        * `:other_key` (list of atom)
 
       """
 


### PR DESCRIPTION
Hi, this adds options types to the documentation generated with `NimbleOptions.docs/2`.