### PR TITLE
Support `tuple` type in typedoc generation

### DIFF
--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -138,6 +138,15 @@ defmodule NimbleOptions.Docs do
     end
   end
 
+  defp get_raw_type_str({:tuple, value_types}) do
+    value_types =
+      value_types
+      |> Enum.map(&get_raw_type_str/1)
+      |> Enum.join(", ")
+
+    "tuple of #{value_types} values"
+  end
+
   defp indent_doc(text, indent) do
     [head | tail] = String.split(text, ["\r\n", "\n"])
 

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -1931,7 +1931,8 @@ defmodule NimbleOptionsTest do
         nested_list_of_ints: [type: {:list, {:list, :integer}}],
         list_of_kws: [type: {:list, {:keyword_list, []}}],
         map: [type: :map],
-        map_of_strings: [type: {:map, :string, :string}]
+        map_of_strings: [type: {:map, :string, :string}],
+        tuple: [type: {:tuple, [:integer, :atom, {:list, :string}]}]
       ]
 
       assert NimbleOptions.docs(schema) == """
@@ -1960,6 +1961,8 @@ defmodule NimbleOptionsTest do
              * `:map` (`t:map/0`)
 
              * `:map_of_strings` (map of `t:String.t/0` keys and `t:String.t/0` values)
+
+             * `:tuple` (tuple of `t:integer/0`, `t:atom/0`, list of `t:String.t/0` values)
 
              """
     end


### PR DESCRIPTION
If an option of type `tuple` was defined a FunctionClauseError was raised because `NimbleOptions.Docs.get_raw_type_str` did not pattern match.