### PR TITLE
Add changelog entry for 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog for NimbleOptions
 
+## v0.5.2
+
+  * Add support for a {:struct, struct_name} type specifier
+    * Example:
+
+        ```elixir
+        schema = [struct: [type: {:struct, URI}]]
+        ```
+  * Add support for the type_doc option
+    * Example:
+
+        ```elixir
+        schema = [
+          foo: [type: :string, type_doc: "`t:SomeModule.t/0`", doc: "The foo."]
+        ]
+        ```
+
 ## v0.5.1
 
   * Support generating typespecs for `:tuple`, `:map`, and `{:map, key, value}` options


### PR DESCRIPTION
Adds changelog entries for
- https://github.com/dashbitco/nimble_options/pull/99
- https://github.com/dashbitco/nimble_options/pull/102

The markdown for the changelog can be previewed at https://github.com/axelson/nimble_options/blob/add-changelog-for-0.5.2/CHANGELOG.md