### PR TITLE
Make t:NimbleOptions.t/0 public

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -305,7 +305,7 @@ defmodule NimbleOptions do
   See the [*Validating Schemas* section](#module-validating-schemas) in
   the module documentation.
   """
-  @opaque t() :: %__MODULE__{schema: schema()}
+  @type t() :: %__MODULE__{schema: schema()}
 
   @doc """
   Validate the given `options` with the given `schema`.


### PR DESCRIPTION
If we keep it opaque, then it's my understanding that we cannot build `NimbleOptions.new!(...)` at **compile-time**, because Dialyzer will complain about opaque types then. :weary: