### PR TITLE
Fix schema_to_spec by adding tuple to `type_to_spec`

### DIFF
--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -257,6 +257,12 @@ defmodule NimbleOptions.Docs do
 
       {:struct, _struct_name} ->
         quote(do: atom())
+
+      {:tuple, [subtype_1, subtype_2]} ->
+        {type_to_spec(subtype_1), type_to_spec(subtype_2)}
+
+      {:tuple, subtypes} ->
+        {:{}, [], Enum.map(subtypes, &type_to_spec/1)}
     end
   end
 

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -1769,7 +1769,9 @@ defmodule NimbleOptionsTest do
         list_of_ne_kw: [type: {:list, {:non_empty_keyword_list, []}}],
         union_scalar: [type: {:or, [:integer, :boolean, :float]}],
         union_complex: [type: {:or, [{:or, [:integer, :float]}, :boolean]}],
-        struct: [type: {:struct, URI}]
+        struct: [type: {:struct, URI}],
+        single_element_tuple: [type: {:tuple, [{:list, :integer}]}],
+        two_element_tuple: [type: {:tuple, [:string, :atom]}]
       ]
 
       assert NimbleOptions.option_typespec(schema) ==
@@ -1801,6 +1803,8 @@ defmodule NimbleOptionsTest do
                   | {:union_scalar, integer() | boolean() | float()}
                   | {:union_complex, (integer() | float()) | boolean()}
                   | {:struct, atom()}
+                  | {:single_element_tuple, {[integer()]}}
+                  | {:two_element_tuple, {binary(), atom()}}
                 end)
     end
   end


### PR DESCRIPTION
When attempting to add `@type option() :: unquote(NimbleOptions.option_typespec(@definition))` to our project I was met with the following error

```
** (CaseClauseError) no case clause matching: {:tuple, [:string, :string]}
    (nimble_options 0.5.2) lib/nimble_options/docs.ex:180: NimbleOptions.Docs.type_to_spec/1
    (nimble_options 0.5.2) lib/nimble_options/docs.ex:250: NimbleOptions.Docs.type_to_spec/1
    (nimble_options 0.5.2) lib/nimble_options/docs.ex:173: anonymous fn/1 in NimbleOptions.Docs.schema_to_spec/1
```

I have added a test that failed and fixed the issue by extending type_to_spec/1 to accept the tuple spec

As always - thanks for all you do and let me know if there are any changes you would like to see to this work!
