### PR TITLE
List of maps bug

### DIFF
--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -130,6 +130,7 @@ defmodule NimbleOptions.Docs do
   defp get_raw_type_str(:string), do: "`t:String.t/0`"
   defp get_raw_type_str(:keyword_list), do: "`t:keyword/0`"
   defp get_raw_type_str(:non_empty_keyword_list), do: "non-empty `t:keyword/0`"
+  defp get_raw_type_str({:map, _keys}), do: "`t:map/0`"
   defp get_raw_type_str({:keyword_list, _keys}), do: "`t:keyword/0`"
   defp get_raw_type_str({:non_empty_keyword_list, _keys}), do: "non-empty `t:keyword/0`"
   defp get_raw_type_str(:map), do: "`t:map/0`"

--- a/test/nimble_options/docs_test.exs
+++ b/test/nimble_options/docs_test.exs
@@ -303,6 +303,7 @@ defmodule NimbleOptions.DocsTest do
         list_of_ints: [type: {:list, :integer}],
         nested_list_of_ints: [type: {:list, {:list, :integer}}],
         list_of_kws: [type: {:list, {:keyword_list, []}}],
+        list_of_maps: [type: {:list, {:map, []}}],
         map: [type: :map],
         map_of_strings: [type: {:map, :string, :string}],
         tuple: [type: {:tuple, [:integer, :atom, {:list, :string}]}],
@@ -331,6 +332,8 @@ defmodule NimbleOptions.DocsTest do
              * `:nested_list_of_ints` (list of list of `t:integer/0`)
 
              * `:list_of_kws` (list of `t:keyword/0`)
+
+             * `:list_of_maps` (list of `t:map/0`)
 
              * `:map` (`t:map/0`)
 


### PR DESCRIPTION
First commit adds test to demonstrate missing functionality, second commit is my best guess at an implementation.

output of failing test:
```
  1) test NimbleOptions.docs/1 autogenerated type docs (NimbleOptions.DocsTest)
     test/nimble_options/docs_test.exs:293
     ** (FunctionClauseError) no function clause matching in NimbleOptions.Docs.get_raw_type_str/1

     The following arguments were given to NimbleOptions.Docs.get_raw_type_str/1:
     
         # 1
         {:map, []}
     
     Attempted function clauses (showing 10 out of 27):
     
         defp get_raw_type_str(nil)
         defp get_raw_type_str({:custom, _mod, _fun, _args})
         defp get_raw_type_str(:mfa)
         defp get_raw_type_str(:mod_arg)
         defp get_raw_type_str({:or, _values})
         defp get_raw_type_str({:in, _})
         defp get_raw_type_str({:fun, arity})
         defp get_raw_type_str(:any)
         defp get_raw_type_str(:reference)
         defp get_raw_type_str(:pid)
         ...
         (17 clauses not shown)
     
     code: assert NimbleOptions.docs(schema) == """
     stacktrace:
       (nimble_options 1.0.2) lib/nimble_options/docs.ex:113: NimbleOptions.Docs.get_raw_type_str/1
       (nimble_options 1.0.2) lib/nimble_options/docs.ex:139: NimbleOptions.Docs.get_raw_type_str/1
       (nimble_options 1.0.2) lib/nimble_options/docs.ex:104: NimbleOptions.Docs.get_type_str/1
       (nimble_options 1.0.2) lib/nimble_options/docs.ex:43: NimbleOptions.Docs.option_doc/2
       (elixir 1.15.2) lib/enum.ex:2510: Enum."-reduce/3-lists^foldl/2-0-"/3
       (nimble_options 1.0.2) lib/nimble_options/docs.ex:6: NimbleOptions.Docs.generate/2
       test/nimble_options/docs_test.exs:313: (test)

............................................................................................................................
Finished in 0.2 seconds (0.2s async, 0.00s sync)
3 doctests, 123 tests, 1 failure
``` 