### PR TITLE
support `:number` type

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -110,6 +110,8 @@ defmodule NimbleOptions do
 
     * `:float` - A float.
 
+    * `:number` - A number.
+
     * `:timeout` - A non-negative integer or the atom `:infinity`.
 
     * `:pid` - A PID (process identifier).
@@ -283,6 +285,7 @@ defmodule NimbleOptions do
     :non_neg_integer,
     :pos_integer,
     :float,
+    :number,
     :mfa,
     :mod_arg,
     :string,
@@ -600,6 +603,14 @@ defmodule NimbleOptions do
       key,
       value,
       "invalid value for #{render_key(key)}: expected float, got: #{inspect(value)}"
+    )
+  end
+
+  defp validate_type(:number, key, value) when not is_number(value) do
+    error_tuple(
+      key,
+      value,
+      "invalid value for #{render_key(key)}: expected number, got: #{inspect(value)}"
     )
   end
 

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -127,6 +127,7 @@ defmodule NimbleOptions.Docs do
   defp get_raw_type_str(:non_neg_integer), do: "`t:non_neg_integer/0`"
   defp get_raw_type_str(:pos_integer), do: "`t:pos_integer/0`"
   defp get_raw_type_str(:float), do: "`t:float/0`"
+  defp get_raw_type_str(:number), do: "`t:number/0`"
   defp get_raw_type_str(:string), do: "`t:String.t/0`"
   defp get_raw_type_str(:keyword_list), do: "`t:keyword/0`"
   defp get_raw_type_str(:non_empty_keyword_list), do: "non-empty `t:keyword/0`"

--- a/test/nimble_options/docs_test.exs
+++ b/test/nimble_options/docs_test.exs
@@ -299,6 +299,7 @@ defmodule NimbleOptions.DocsTest do
         kw: [type: :keyword_list],
         nonempty_kw: [type: :non_empty_keyword_list],
         int: [type: :integer],
+        num: [type: :number],
         ref: [type: :reference],
         list_of_ints: [type: {:list, :integer}],
         nested_list_of_ints: [type: {:list, {:list, :integer}}],
@@ -324,6 +325,8 @@ defmodule NimbleOptions.DocsTest do
              * `:nonempty_kw` (non-empty `t:keyword/0`)
 
              * `:int` (`t:integer/0`)
+
+             * `:num` (`t:number/0`)
 
              * `:ref` (`t:reference/0`)
 

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -40,7 +40,7 @@ defmodule NimbleOptionsTest do
       Reason: invalid value for :type option: unknown type :foo.
 
       Available types: :any, :keyword_list, :non_empty_keyword_list, :map, :atom, \
-      :integer, :non_neg_integer, :pos_integer, :float, :mfa, :mod_arg, :string, :boolean, :timeout, \
+      :integer, :non_neg_integer, :pos_integer, :float, :number, :mfa, :mod_arg, :string, :boolean, :timeout, \
       :pid, :reference, nil, {:fun, arity}, {:in, choices}, {:or, subtypes}, {:custom, mod, fun, args}, \
       {:list, subtype}, {:tuple, list_of_subtypes}, {:map, key_type, value_type}, {:struct, struct_name} \
       (in options [:stages])\
@@ -299,6 +299,26 @@ defmodule NimbleOptionsTest do
                   key: :certainty,
                   value: :an_atom,
                   message: "invalid value for :certainty option: expected float, got: :an_atom"
+                }}
+    end
+
+    test "valid number" do
+      schema = [multiplier: [type: :number]]
+
+      assert NimbleOptions.validate([multiplier: 1], schema) == {:ok, [multiplier: 1]}
+      assert NimbleOptions.validate([multiplier: 2.3], schema) == {:ok, [multiplier: 2.3]}
+      assert NimbleOptions.validate([multiplier: -4], schema) == {:ok, [multiplier: -4]}
+    end
+
+    test "invalid number" do
+      schema = [multiplier: [type: :number]]
+
+      assert NimbleOptions.validate([multiplier: :an_atom], schema) ==
+               {:error,
+                %ValidationError{
+                  key: :multiplier,
+                  value: :an_atom,
+                  message: "invalid value for :multiplier option: expected number, got: :an_atom"
                 }}
     end
 


### PR DESCRIPTION
In many cases we don't care if the option is `:integer` or `:float`. You can use `{:or, [:integer, :float]}` but since this is very common it makes sense to expose it as a supported type.