### PR TITLE
Add deprecated to docs

### DIFF
--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -80,7 +80,7 @@ defmodule NimbleOptions.Docs do
   defp get_deprecated_str(prev_str, schema) do
     space_concat(
       prev_str,
-      schema[:deprecated] && "This option is deprecated. #{String.trim(schema[:deprecated])}"
+      schema[:deprecated] && "*This option is deprecated. #{String.trim(schema[:deprecated])}*"
     )
   end
 

--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -45,6 +45,7 @@ defmodule NimbleOptions.Docs do
 
     description =
       get_required_str(schema)
+      |> get_deprecated_str(schema)
       |> get_doc_str(schema)
       |> get_default_str(schema)
       |> case do
@@ -74,6 +75,13 @@ defmodule NimbleOptions.Docs do
 
   defp get_required_str(schema) do
     if schema[:required], do: "Required."
+  end
+
+  defp get_deprecated_str(prev_str, schema) do
+    space_concat(
+      prev_str,
+      schema[:deprecated] && "This option is deprecated. #{String.trim(schema[:deprecated])}"
+    )
   end
 
   defp get_doc_str(prev_str, schema) do

--- a/test/nimble_options/docs_test.exs
+++ b/test/nimble_options/docs_test.exs
@@ -236,6 +236,22 @@ defmodule NimbleOptions.DocsTest do
       assert NimbleOptions.docs(schema) == docs
     end
 
+    test "generates deprecated information" do
+      schema = [
+        old: [type: :atom, doc: "Old option.", deprecated: "Use `:new` instead."],
+        new: [type: :string, doc: "New option."]
+      ]
+
+      docs = """
+      * `:old` (`t:atom/0`) - This option is deprecated. Use `:new` instead. Old option.
+
+      * `:new` (`t:String.t/0`) - New option.
+
+      """
+
+      assert NimbleOptions.docs(schema) == docs
+    end
+
     test "the option doesn't appear in the documentation when the :doc option is false" do
       schema = [
         name: [type: :atom, doc: "An atom."],

--- a/test/nimble_options/docs_test.exs
+++ b/test/nimble_options/docs_test.exs
@@ -243,7 +243,7 @@ defmodule NimbleOptions.DocsTest do
       ]
 
       docs = """
-      * `:old` (`t:atom/0`) - This option is deprecated. Use `:new` instead. Old option.
+      * `:old` (`t:atom/0`) - *This option is deprecated. Use `:new` instead.* Old option.
 
       * `:new` (`t:String.t/0`) - New option.
 


### PR DESCRIPTION
Adds deprecated information to docs.

Example from [Finch docs](https://hexdocs.pm/finch/Finch.html#start_link/1-pool-configuration-options)
| Before         |  After         |
:---------------:|:---------------:
![](https://github.com/dashbitco/nimble_options/assets/1627293/c37cfa7c-55c4-4cbf-af5a-007e33e77ade) | ![](https://github.com/dashbitco/nimble_options/assets/1627293/96769160-c061-43c0-9f13-c8ac9b5a75c2)
