### PR TITLE
Fix value of "received options" in error message

### DIFF
--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -116,6 +116,22 @@ defmodule NimbleOptionsTest do
                }
              }
     end
+
+    test "is not treated as values of received options when showing validation error" do
+      # It is intentional to define options with default values at the beginning of the list.
+      # Don't change the order of them.
+      schema = [age: [type: :non_neg_integer, default: 10], name: [type: :string, required: true]]
+
+      assert NimbleOptions.validate([], schema) == {
+               :error,
+               %NimbleOptions.ValidationError{
+                 key: :name,
+                 keys_path: [],
+                 message: "required :name option not found, received options: []",
+                 value: nil
+               }
+             }
+    end
   end
 
   describe ":required" do


### PR DESCRIPTION
This PR aims to close #127.

* In order to get the original opts when composing the error message, I extended the second argument of `reduce_options/2`.
* There is also a trivial modification that unifies the function signatures of `validate_unknown_options/2` and `validate_options/2`.

> I am not very confident in the elegance of this code; comments are welcome, and I am happy to make revisions.