### PR TITLE
Allow map options in validate/2 when schema is a list

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -342,7 +342,7 @@ defmodule NimbleOptions do
     validate_options_with_schema(options, schema)
   end
 
-  def validate(options, schema) when is_list(options) and is_list(schema) do
+  def validate(options, schema) when (is_list(options) or is_map(options)) and is_list(schema) do
     validate(options, new!(schema))
   end
 

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -1735,6 +1735,32 @@ defmodule NimbleOptionsTest do
     end
   end
 
+  # No other test is passing in `opts` as a map, so these are just some white box tests for sanity checking
+  describe "can use a map for validate/2" do
+    schema = []
+    opts = %{}
+    assert NimbleOptions.validate(opts, schema) == {:ok, %{}}
+
+    schema = [
+      name: [type: :string, required: true],
+      context: [type: :atom, required: false]
+    ]
+
+    opts = %{}
+
+    assert NimbleOptions.validate(opts, schema) ==
+             {:error,
+              %ValidationError{
+                key: :name,
+                value: nil,
+                keys_path: [],
+                message: "required :name option not found, received options: []"
+              }}
+
+    opts = %{name: "primary 1"}
+    assert NimbleOptions.validate(opts, schema) == {:ok, %{name: "primary 1"}}
+  end
+
   describe "validate!/2 (raising version)" do
     test "returns the direct options if the options are valid" do
       schema = [name: [], context: []]


### PR DESCRIPTION
If I have the following:

```elixir
NimbleOptions.validate(opts, NimbleOptions.new!(schema))
```

Everything works fine, but if I do:

```elixir
NimbleOptions.validate(opts, schema)
```

It doesn't work 😢