### PR TITLE
Support redacting sensitive options

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -83,6 +83,7 @@ defmodule NimbleOptions do
           doc: """
           Ensures that sensitive information is not included in error messages and hides any
           sensitive values when inspecting the `NimbleOptions.ValidationError` struct.
+          *Available since v1.2.0*.
           """
         ]
       ]

--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -1143,16 +1143,20 @@ defmodule NimbleOptions do
     {:error, "unknown type #{inspect(value)}.\n\nAvailable types: #{available_types()}"}
   end
 
+  defp error_tuple(key, value, message) do
+    error_tuple(key, value, message, false)
+  end
+
+  defp error_tuple(key, value, message, redact) do
+    {:error, %ValidationError{key: key, message: message, redact: redact, value: value}}
+  end
+
   defp error_tuple(key, value, message, _, true) do
-    error_tuple(key, value, message)
+    error_tuple(key, value, message, true)
   end
 
   defp error_tuple(key, value, message, unredacted_message, false) do
-    error_tuple(key, value, message <> unredacted_message)
-  end
-
-  defp error_tuple(key, value, message) do
-    {:error, %ValidationError{key: key, message: message, value: value}}
+    error_tuple(key, value, message <> unredacted_message, false)
   end
 
   defp render_key({__MODULE__, :key}), do: "map key"

--- a/test/nimble_options/validation_error_test.exs
+++ b/test/nimble_options/validation_error_test.exs
@@ -1,6 +1,8 @@
 defmodule NimbleOptions.ValidationErrorTest do
   use ExUnit.Case, async: true
 
+  alias NimbleOptions.ValidationError
+
   test "does not redact value when redact option is false" do
     schema = [foo: [type: :integer]]
 
@@ -19,5 +21,15 @@ defmodule NimbleOptions.ValidationErrorTest do
     {:error, error} = NimbleOptions.validate(opts, schema)
 
     assert inspect(error) =~ "value: \"**redacted**\""
+  end
+
+  test "message is redacted when an error is raised" do
+    schema = [foo: [type: :integer, redact: true]]
+
+    opts = [foo: "not an integer"]
+
+    assert_raise(ValidationError, "invalid value for :foo option: expected integer", fn ->
+      NimbleOptions.validate!(opts, schema)
+    end)
   end
 end

--- a/test/nimble_options/validation_error_test.exs
+++ b/test/nimble_options/validation_error_test.exs
@@ -1,0 +1,23 @@
+defmodule NimbleOptions.ValidationErrorTest do
+  use ExUnit.Case, async: true
+
+  test "does not redact value when redact option is false" do
+    schema = [foo: [type: :integer]]
+
+    opts = [foo: "not an integer"]
+
+    {:error, error} = NimbleOptions.validate(opts, schema)
+
+    assert inspect(error) =~ "value: \"not an integer\""
+  end
+
+  test "redacts value when redact option is true" do
+    schema = [foo: [type: :integer, redact: true]]
+
+    opts = [foo: "not an integer"]
+
+    {:error, error} = NimbleOptions.validate(opts, schema)
+
+    assert inspect(error) =~ "value: \"**redacted**\""
+  end
+end

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -290,6 +290,26 @@ defmodule NimbleOptionsTest do
                 }}
     end
 
+    test "redacted invalid integer" do
+      schema = [min_demand: [type: :integer, redact: true]]
+
+      assert NimbleOptions.validate([min_demand: 1.5], schema) ==
+               {:error,
+                %ValidationError{
+                  key: :min_demand,
+                  value: 1.5,
+                  message: "invalid value for :min_demand option: expected integer"
+                }}
+
+      assert NimbleOptions.validate([min_demand: :an_atom], schema) ==
+               {:error,
+                %ValidationError{
+                  key: :min_demand,
+                  value: :an_atom,
+                  message: "invalid value for :min_demand option: expected integer"
+                }}
+    end
+
     test "valid non negative integer" do
       schema = [min_demand: [type: :non_neg_integer]]
       opts = [min_demand: 0]

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -72,7 +72,7 @@ defmodule NimbleOptionsTest do
       Reason: \
       unknown options [:unknown_schema_option], \
       valid options are: [:type, :required, :default, :keys, \
-      :deprecated, :doc, :subsection, :type_doc, :type_spec] \
+      :deprecated, :doc, :subsection, :type_doc, :type_spec, :redact] \
       (in options [:producers, :keys, :*, :keys, :module])\
       """
 
@@ -129,6 +129,34 @@ defmodule NimbleOptionsTest do
                  keys_path: [],
                  message: "required :name option not found, received options: []",
                  value: nil
+               }
+             }
+    end
+
+    test "is redacted" do
+      schema = [
+        processors: [
+          type: :keyword_list,
+          default: [],
+          keys: [
+            stages: [
+              type: :integer,
+              default: "10",
+              redact: true
+            ]
+          ]
+        ]
+      ]
+
+      opts = [processors: []]
+
+      assert NimbleOptions.validate(opts, schema) == {
+               :error,
+               %ValidationError{
+                 key: :stages,
+                 keys_path: [:processors],
+                 message: "invalid value for :stages option: expected integer",
+                 value: "10"
                }
              }
     end

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -156,7 +156,8 @@ defmodule NimbleOptionsTest do
                  key: :stages,
                  keys_path: [:processors],
                  message: "invalid value for :stages option: expected integer",
-                 value: "10"
+                 value: "10",
+                 redact: true
                }
              }
     end
@@ -271,7 +272,8 @@ defmodule NimbleOptionsTest do
                 %ValidationError{
                   key: :stages,
                   value: 0,
-                  message: "invalid value for :stages option: expected positive integer"
+                  message: "invalid value for :stages option: expected positive integer",
+                  redact: true
                 }}
     end
 
@@ -310,7 +312,8 @@ defmodule NimbleOptionsTest do
                 %ValidationError{
                   key: :min_demand,
                   value: 1.5,
-                  message: "invalid value for :min_demand option: expected integer"
+                  message: "invalid value for :min_demand option: expected integer",
+                  redact: true
                 }}
     end
 
@@ -351,7 +354,8 @@ defmodule NimbleOptionsTest do
                 %ValidationError{
                   key: :min_demand,
                   value: -1,
-                  message: "invalid value for :min_demand option: expected non negative integer"
+                  message: "invalid value for :min_demand option: expected non negative integer",
+                  redact: true
                 }}
     end
 
@@ -390,7 +394,8 @@ defmodule NimbleOptionsTest do
                 %ValidationError{
                   key: :certainty,
                   value: 1,
-                  message: "invalid value for :certainty option: expected float"
+                  message: "invalid value for :certainty option: expected float",
+                  redact: true
                 }}
     end
 
@@ -420,7 +425,8 @@ defmodule NimbleOptionsTest do
                 %ValidationError{
                   key: :name,
                   value: 1,
-                  message: "invalid value for :name option: expected atom"
+                  message: "invalid value for :name option: expected atom",
+                  redact: true
                 }}
     end
 
@@ -526,7 +532,8 @@ defmodule NimbleOptionsTest do
                   key: :timeout,
                   value: -1,
                   message:
-                    "invalid value for :timeout option: expected non-negative integer or :infinity"
+                    "invalid value for :timeout option: expected non-negative integer or :infinity",
+                  redact: true
                 }}
     end
 
@@ -556,7 +563,8 @@ defmodule NimbleOptionsTest do
                 %ValidationError{
                   key: :name,
                   value: 1,
-                  message: "invalid value for :name option: expected pid"
+                  message: "invalid value for :name option: expected pid",
+                  redact: true
                 }}
     end
 
@@ -586,7 +594,8 @@ defmodule NimbleOptionsTest do
                 %ValidationError{
                   key: :name,
                   value: 1,
-                  message: "invalid value for :name option: expected reference"
+                  message: "invalid value for :name option: expected reference",
+                  redact: true
                 }}
     end
 
@@ -662,7 +671,9 @@ defmodule NimbleOptionsTest do
                %ValidationError{
                  key: :transformer,
                  value: {"not_a_module", :func, []},
-                 message: "invalid value for :transformer option: expected tuple {mod, fun, args}"
+                 message:
+                   "invalid value for :transformer option: expected tuple {mod, fun, args}",
+                 redact: true
                }
              }
     end
@@ -715,7 +726,8 @@ defmodule NimbleOptionsTest do
                %ValidationError{
                  key: :producer,
                  value: NotATuple,
-                 message: ~s(invalid value for :producer option: expected tuple {mod, arg})
+                 message: ~s(invalid value for :producer option: expected tuple {mod, arg}),
+                 redact: true
                }
              }
     end
@@ -768,7 +780,9 @@ defmodule NimbleOptionsTest do
                %ValidationError{
                  key: :partition_by,
                  value: :not_a_fun,
-                 message: ~s(invalid value for :partition_by option: expected function of arity 1)
+                 message:
+                   ~s(invalid value for :partition_by option: expected function of arity 1),
+                 redact: true
                }
              }
 
@@ -779,7 +793,9 @@ defmodule NimbleOptionsTest do
                %ValidationError{
                  key: :partition_by,
                  value: opts[:partition_by],
-                 message: ~s(invalid value for :partition_by option: expected function of arity 1)
+                 message:
+                   ~s(invalid value for :partition_by option: expected function of arity 1),
+                 redact: true
                }
              }
     end
@@ -812,7 +828,8 @@ defmodule NimbleOptionsTest do
                 %ValidationError{
                   key: :name,
                   value: :not_nil,
-                  message: "invalid value for :name option: expected nil"
+                  message: "invalid value for :name option: expected nil",
+                  redact: true
                 }}
     end
 
@@ -893,7 +910,9 @@ defmodule NimbleOptionsTest do
                 %ValidationError{
                   key: :batch_mode,
                   value: :invalid,
-                  message: "invalid value for :batch_mode option: expected one of [:flush, :bulk]"
+                  message:
+                    "invalid value for :batch_mode option: expected one of [:flush, :bulk]",
+                  redact: true
                 }}
     end
 
@@ -1232,7 +1251,8 @@ defmodule NimbleOptionsTest do
                   key: :metadata,
                   keys_path: [],
                   message: "invalid value for :metadata option: expected list",
-                  value: "not a list"
+                  value: "not a list",
+                  redact: true
                 }}
 
       # List with invalid elements
@@ -1441,7 +1461,8 @@ defmodule NimbleOptionsTest do
                   key: :result,
                   keys_path: [],
                   message: "invalid value for :result option: expected tuple",
-                  value: "not a tuple"
+                  value: "not a tuple",
+                  redact: true
                 }}
 
       # List with invalid elements
@@ -1566,7 +1587,8 @@ defmodule NimbleOptionsTest do
                   key: :map,
                   keys_path: [],
                   message: "invalid value for :map option: expected map",
-                  value: "not a map"
+                  value: "not a map",
+                  redact: true
                 }}
 
       schema = [map: [type: :map, keys: [key: [type: :string, redact: true]]]]
@@ -1579,7 +1601,8 @@ defmodule NimbleOptionsTest do
                   key: :key,
                   keys_path: [:map],
                   message: "invalid value for :key option: expected string",
-                  value: :atom_value
+                  value: :atom_value,
+                  redact: true
                 }}
     end
 
@@ -1748,7 +1771,8 @@ defmodule NimbleOptionsTest do
                   key: :struct,
                   keys_path: [],
                   message: "invalid value for :struct option: expected URI",
-                  value: %NimbleOptions{schema: []}
+                  value: %NimbleOptions{schema: []},
+                  redact: true
                 }}
     end
   end
@@ -2136,7 +2160,8 @@ defmodule NimbleOptionsTest do
                 %ValidationError{
                   key: :producers,
                   value: [],
-                  message: "invalid value for :producers option: expected non-empty keyword list"
+                  message: "invalid value for :producers option: expected non-empty keyword list",
+                  redact: true
                 }}
     end
 


### PR DESCRIPTION
Wanted to get some initial work in front of you all to make sure my approach is acceptable.

My main concern with this implementation is trying to centralize the redact logic as much as I can. Since this is a security minded feature I want to make sure that future contributors don't need to implement redaction themselves so I'm making it part of the implementation pattern for types.

Let me know if you feel like I'm on the right track or not. Open to suggestions as well.