### PR TITLE
Support validation type for `:integer`

### DIFF
--- a/lib/nimble_options/validation_error.ex
+++ b/lib/nimble_options/validation_error.ex
@@ -12,6 +12,7 @@ defmodule NimbleOptions.ValidationError do
           key: atom(),
           keys_path: [atom()],
           redact: boolean,
+          validation: :required | {:type, term()},
           value: term()
         }
 
@@ -28,8 +29,10 @@ defmodule NimbleOptions.ValidationError do
     * `:value` (`t:term/0`) - The value that failed to validate. This field is `nil` if there
       was no value provided.
 
+    * `:validation` (`:required` or `{:type, type}`) - The validation that failed.
+
   """
-  defexception [:message, :key, :value, keys_path: [], redact: false]
+  defexception [:message, :key, :validation, :value, keys_path: [], redact: false]
 
   @impl true
   def message(%__MODULE__{message: message, keys_path: keys_path}) do

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -292,6 +292,7 @@ defmodule NimbleOptionsTest do
                 %ValidationError{
                   key: :min_demand,
                   value: 1.5,
+                  validation: {:type, :integer},
                   message: "invalid value for :min_demand option: expected integer, got: 1.5"
                 }}
 


### PR DESCRIPTION
@whatyouhide initial attempt at adding failed validation to `NimbleOptions.ValidationError`. Only implemented support for `{:type, :integer}`  so I can get a sanity check on whether you think I'm on the right path.