### PR TITLE
Fixed `describe` block that should be `test`

### DIFF
--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -2250,7 +2250,7 @@ defmodule NimbleOptionsTest do
   end
 
   # No other test is passing in `opts` as a map, so these are just some white box tests for sanity checking
-  describe "can use a map for validate/2" do
+  test "can use a map for validate/2" do
     schema = []
     opts = %{}
     assert NimbleOptions.validate(opts, schema) == {:ok, %{}}


### PR DESCRIPTION
Ran into a testing issue while working on #134 and saw `describe` being used instead of `test`.