### PR TITLE
Clarify the usage of custom type

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -158,9 +158,8 @@ defmodule NimbleOptions do
       called `:one_of` and the `:in` name is available since version 0.3.3 (`:one_of`
       has been removed in v0.4.0).
 
-    * `{:custom, mod, fun, args}` - A custom type. The related value must be validated
-      by `mod.fun(values, ...args)`. The function should return `{:ok, value}` or
-      `{:error, message}`.
+    * `{:custom, mod, fun, args}` - A custom type. The related value will be validated
+      by `apply(mod, fun, [value | args])`. `fun` should return `{:ok, value}` or `{:error, message}`.
 
     * `{:or, subtypes}` - A value that matches one of the given `subtypes`. The value is
       matched against the subtypes in the order specified in the list of `subtypes`. If


### PR DESCRIPTION
Before, the doc uses `mod.fun(values, ...args)` to describe the usage of custom type. However, it failed to clearly explain the underlying approach, because `...` is not a valid syntax of Elixir.

This PR try to clarify the usage by referring the underlying call. 

> Although covering the underlying implementation in the documentation is not ideal, it is likely the easiest way to understand how things work, especially since developers are indeed required to implement certain aspects here.