### PR TITLE
Use Logger.warning instead of IO.warn

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -295,6 +295,8 @@ defmodule NimbleOptions do
 
   alias NimbleOptions.ValidationError
 
+  require Logger
+
   defstruct schema: []
 
   @basic_types [
@@ -582,7 +584,7 @@ defmodule NimbleOptions do
     cond do
       Keyword.has_key?(opts, key) ->
         if message = Keyword.get(schema, :deprecated) do
-          IO.warn("#{render_key(key)} is deprecated. " <> message)
+          Logger.warning("#{render_key(key)} is deprecated. " <> message)
         end
 
         {:ok, opts[key]}


### PR DESCRIPTION
Using IO.warn doesn't allow hiding the logs in environments where the log level is above warning.

This becomes an issue for test environments where one might still be testing the deprecated flags but doesn't want to show the deprecation log messages.
Also IO.warn messages won't be formatted using the logger formatter that one might be using in production environments.