### PR TITLE
Fix ignoring schema when wildcard-key is defined

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -898,7 +898,7 @@ defmodule NimbleOptions do
         keys
 
       schema_opts ->
-        Enum.map(opts, fn {k, _} -> {k, schema_opts} end)
+        keys ++ Enum.map(opts, fn {k, _} -> {k, schema_opts} end)
     end
   end
 

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -93,6 +93,11 @@ defmodule NimbleOptionsTest do
       assert NimbleOptions.validate([context: :given], schema) == {:ok, [context: :given]}
     end
 
+    test "is used when wildcard-key is defined" do
+      schema = [context: [default: :ok], *: [type: :any]]
+      assert NimbleOptions.validate([], schema) == {:ok, [context: :ok]}
+    end
+
     test "is validated" do
       schema = [
         processors: [


### PR DESCRIPTION
Currently, schemas with wildcard-key defined misbehave:

```elixir
iex(1)> NimbleOptions.validate [], [table: [doc: "ETS table to use", type: :atom, default: nil], *: [type: :any]]
{:ok, []}
iex(2)> NimbleOptions.validate [], [table: [doc: "ETS table to use", type: :atom, default: nil]]
{:ok, [table: nil]}
```

The reason is that `NimbleOptions.expand_star_to_option_keys/2` ignores all other keys, except *present in the data* when handling wildcard.

Is that intended?