### PR TITLE
Fix struct update syntax deprecation warning elixir 1.19.0-dev

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -517,7 +517,7 @@ defmodule NimbleOptions do
       {:ok, options}
     else
       {:error, %ValidationError{} = error} ->
-        {:error, %ValidationError{error | keys_path: path ++ error.keys_path}}
+        {:error, %{error | keys_path: path ++ error.keys_path}}
     end
   end
 


### PR DESCRIPTION
Fixes

```
     warning: the struct update syntax is deprecated:

     %NimbleOptions.ValidationError{error | keys_path: path ++ error.keys_path}

     Instead, prefer to pattern matching on structs when the variable is first defined and use the regular map update syntax instead:

     %{error | keys_path: path ++ error.keys_path}

     │
 520 │         {:error, %ValidationError{error | keys_path: path ++ error.keys_path}}
     │                                  ~
     │
     └─ lib/nimble_options.ex:520:34
```