### PR TITLE
Add NimbleOwnership library reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ All nimble libraries by Dashbit:
 
   * [NimbleCSV](https://github.com/dashbitco/nimble_csv) - simple and fast CSV parsing
   * [NimbleOptions](https://github.com/dashbitco/nimble_options) - tiny library for validating and documenting high-level options
+  * [NimbleOwnership](https://github.com/dashbitco/nimble_ownership) - resource ownership tracking
   * [NimbleParsec](https://github.com/dashbitco/nimble_parsec) - simple and fast parser combinators
   * [NimblePool](https://github.com/dashbitco/nimble_pool) - tiny resource-pool implementation
   * [NimblePublisher](https://github.com/dashbitco/nimble_publisher) - a minimal filesystem-based publishing engine with Markdown support and code highlighting


### PR DESCRIPTION
The changes add a link to the [NimbleOwnership](https://github.com/dashbitco/nimble_ownership) library

I took the wording from the NimbleOwnership's [README](https://github.com/dashbitco/nimble_ownership?tab=readme-ov-file#nimble) section