### PR TITLE
Fix `type_to_spec/1` for map with keys.

### DIFF
--- a/lib/nimble_options/docs.ex
+++ b/lib/nimble_options/docs.ex
@@ -246,6 +246,9 @@ defmodule NimbleOptions.Docs do
       :map ->
         quote(do: map())
 
+      {:map, _keys} ->
+        quote(do: map())
+
       {:map, key_type, value_type} ->
         quote(
           do: %{optional(unquote(type_to_spec(key_type))) => unquote(type_to_spec(value_type))}


### PR DESCRIPTION
Fixes typespec generation for any schema that contains a `{:list, {:map, keys}}` or `{:or, [map: keys, ...]}` type.