### PR TITLE
Fix inspect exception with ANSI enabled

### DIFF
--- a/lib/nimble_options/validation_error.ex
+++ b/lib/nimble_options/validation_error.ex
@@ -51,11 +51,10 @@ defmodule NimbleOptions.ValidationError do
         |> Map.drop([:__struct__, :__exception__])
         |> Map.update!(:value, &if(redacted?, do: "**redacted**", else: &1))
         |> Enum.sort_by(fn {key, _val} -> key end)
-        |> Enum.map(fn {key, val} -> [string("#{key}:"), break(), to_doc(val, opts)] end)
-        |> Enum.intersperse([string(","), break()])
-        |> List.flatten()
+        |> Enum.map(fn {key, val} -> concat([string("#{key}: "), to_doc(val, opts)]) end)
+        |> Enum.intersperse(string(", "))
 
-      concat(["##{inspect(@for)}<"] ++ fields ++ [">"])
+      concat(["##{inspect(@for)}<", concat(fields), ">"])
     end
   end
 end

--- a/test/nimble_options/validation_error_test.exs
+++ b/test/nimble_options/validation_error_test.exs
@@ -45,6 +45,16 @@ defmodule NimbleOptions.ValidationErrorTest do
                ~s(#NimbleOptions.ValidationError<key: :foo, keys_path: [], message: "invalid value for :foo option: expected integer, got: true", redact: false, value: true>)
     end
 
+    test "with syntax colors" do
+      schema = [foo: [type: :integer]]
+      opts = [foo: true]
+
+      {:error, error} = NimbleOptions.validate(opts, schema)
+
+      assert inspect(error, syntax_colors: [atom: :red]) ==
+               ~s(#NimbleOptions.ValidationError<key: \e[31m:foo\e[0m, keys_path: [], message: "invalid value for :foo option: expected integer, got: true", redact: false, value: true>)
+    end
+
     test "with a redacted option" do
       schema = [foo: [type: :integer, redact: true]]
 


### PR DESCRIPTION
```elixir
iex(1)> schema = [foo: [type: :integer]]
[foo: [type: :integer]]
iex(2)> NimbleOptions.validate([transformer: "test"], schema)
{:error,
 #Inspect.Error<
  got FunctionClauseError with message:

      """
      no function clause matching in :lists.do_flatten/2
      """

  while inspecting:

      %{
        message: "unknown options [:transformer], valid options are: [:foo]",
        value: nil,
        key: [:transformer],
        __struct__: NimbleOptions.ValidationError,
        __exception__: true,
        redact: false,
        keys_path: []
      }

  Stacktrace:

    (stdlib 7.3) lists.erl:1322: :lists.do_flatten({:doc_color, [], "\e[0m\e[33m"}, [])
    (stdlib 7.3) lists.erl:1325: :lists.do_flatten/2
    (stdlib 7.3) lists.erl:1323: :lists.do_flatten/2
    (nimble_options 1.1.1) lib/nimble_options/validation_error.ex:56: Inspect.NimbleOptions.ValidationError.inspect/2
    (elixir 1.19.3) lib/inspect/algebra.ex:401: Inspect.Algebra.to_doc_with_opts/2
    (elixir 1.19.3) lib/inspect/algebra.ex:613: Inspect.Algebra.call_container_fun/3
    (elixir 1.19.3) lib/inspect/algebra.ex:590: Inspect.Algebra.container_each/5
    (elixir 1.19.3) lib/inspect/algebra.ex:566: Inspect.Algebra.container_doc_with_opts/6

>}
```