### PR TITLE
Fix invalid mfa validation if value was `nil`

### DIFF
--- a/lib/nimble_options.ex
+++ b/lib/nimble_options.ex
@@ -700,7 +700,7 @@ defmodule NimbleOptions do
     {:ok, value}
   end
 
-  defp validate_type(:mfa, key, value, redact) when not is_nil(value) do
+  defp validate_type(:mfa, key, value, redact) do
     structured_error_tuple(key, value, "tuple {mod, fun, args}", inspect(value), redact)
   end
 

--- a/test/nimble_options_test.exs
+++ b/test/nimble_options_test.exs
@@ -666,6 +666,22 @@ defmodule NimbleOptionsTest do
              }
     end
 
+    test "mfa rejects nil" do
+      schema = [transformer: [type: :mfa]]
+
+      opts = [transformer: nil]
+
+      assert NimbleOptions.validate(opts, schema) == {
+               :error,
+               %ValidationError{
+                 key: :transformer,
+                 value: nil,
+                 message:
+                   "invalid value for :transformer option: expected tuple {mod, fun, args}, got: nil"
+               }
+             }
+    end
+
     test "redacted invalid mfa" do
       schema = [transformer: [type: :mfa, redact: true]]
 


### PR DESCRIPTION
```elixir
iex(1)> schema = [foo: [type: :mfa]]
[foo: [type: :mfa]]
iex(2)> NimbleOptions.validate([foo: nil], schema)
{:ok, [foo: nil]}
```