### PR TITLE
Widen ValidationError :key type to allow lists

### DIFF
--- a/lib/nimble_options/validation_error.ex
+++ b/lib/nimble_options/validation_error.ex
@@ -9,7 +9,7 @@ defmodule NimbleOptions.ValidationError do
   """
 
   @type t() :: %__MODULE__{
-          key: atom(),
+          key: atom() | [atom()],
           keys_path: [atom()],
           redact: boolean,
           value: term()
@@ -21,7 +21,9 @@ defmodule NimbleOptions.ValidationError do
   Only the following documented fields are considered public. All other fields are
   considered private and should not be referenced:
 
-    * `:key` (`t:atom/0`) - The key that did not successfully validate.
+    * `:key` (`t:atom/0` or list of `t:atom/0`) - The key that did not successfully
+      validate. When several keys are involved in the same error (for example,
+      unknown options reported as a group), this is the list of those keys.
 
     * `:keys_path` (list of `t:atom/0`) - If the key is nested, this is the path to the key.
 


### PR DESCRIPTION
## Summary

`%NimbleOptions.ValidationError{}.key` is typed `atom()` but the struct already stores a list of atoms for the "unknown options" case. This PR widens the type to match runtime behavior.

## Evidence

- The "unknown options" error path passes a list of keys at `lib/nimble_options.ex:524`:

  ```elixir
  keys ->
    error_tuple(
      keys,
      nil,
      "unknown options #{inspect(keys)}, valid options are: #{inspect(valid_opts)}"
    )
  ```

- `test "unknown options"` asserts the list form:

  ```elixir
  key: [:not_an_option1, :not_an_option2]
  ```

- Runtime behavior is intentional. The typespec was misleading.

## Why this matters

The set-theoretic type checker introduced in elixir-lang/elixir#15366 reads `@type t :: %__MODULE__{key: atom()}` literally. Every call site that passes a list where `atom()` is declared fires a warning. `nimble_options` is depended on by several top Hex packages (finch, oban, req, swoosh, tesla, ex_aws, phoenix_live_view), so this single mismatch cascades into downstream warnings for their consumers.

Widening the type matches what the code already does. No code change, no test change.

## Change

```diff
-          key: atom(),
+          key: atom() | [atom()],
```

Plus a doc update on the `:key` field calling out the multi-key case.

## Verification

`mix test`: 156/156 pass. `mix compile` clean under the new checker.
